### PR TITLE
Remove redundant 'files' suffix from preview section file count

### DIFF
--- a/internal/tui/view_preview.go
+++ b/internal/tui/view_preview.go
@@ -282,7 +282,7 @@ func (m *Model) renderSectionLine(r *types.ScanResult, isCurrentSection bool, is
 	}
 
 	size := fmt.Sprintf("%*s", sizeWidth, formatSize(m.getEffectiveSize(r)))
-	count := fmt.Sprintf("%*s", countWidth, fmt.Sprintf("%d files", r.TotalFileCount))
+	count := fmt.Sprintf("%*s", countWidth, fmt.Sprintf("%d", r.TotalFileCount))
 
 	return fmt.Sprintf("%s%s %s %s %s %s", cursor, indicator, name, badge, styles.SizeStyle.Render(size), styles.MutedStyle.Render(count))
 }


### PR DESCRIPTION
## What changed

- Remove "files" suffix from section-level file count in preview view (e.g. 123 files → 123)

## Why

- Column header already says "Files", so the suffix is redundant


## How to test (optional)

- Run app and navigate to preview page, check section rows show numbers only
