### PR TITLE
Adapt color palette and styles to terminal background

### DIFF
--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -22,12 +22,12 @@ const (
 )
 
 // FormatReport renders a plain-text report for CLI output.
-func FormatReport(report *types.Report, dryRun bool) string {
+func FormatReport(report *types.Report, dryRun bool, theme styles.Styles) string {
 	if report == nil {
 		return "No report available.\n"
 	}
 
-	styles := newReportStyles()
+	styles := newReportStyles(theme)
 
 	title := "Cleanup Report"
 	if dryRun {
@@ -224,16 +224,16 @@ type reportStyles struct {
 	muted   lipgloss.Style
 }
 
-func newReportStyles() reportStyles {
+func newReportStyles(theme styles.Styles) reportStyles {
 	enabled := shouldColorize()
 	return reportStyles{
 		enabled: enabled,
-		title:   lipgloss.NewStyle().Foreground(styles.ColorPrimary).Bold(true),
-		section: lipgloss.NewStyle().Foreground(styles.ColorSecondary).Bold(true),
-		success: lipgloss.NewStyle().Foreground(styles.ColorSuccess).Bold(true),
-		warn:    lipgloss.NewStyle().Foreground(styles.ColorWarning).Bold(true),
-		danger:  lipgloss.NewStyle().Foreground(styles.ColorDanger).Bold(true),
-		muted:   lipgloss.NewStyle().Foreground(styles.ColorMuted),
+		title:   lipgloss.NewStyle().Foreground(theme.Primary).Bold(true),
+		section: lipgloss.NewStyle().Foreground(theme.Secondary).Bold(true),
+		success: lipgloss.NewStyle().Foreground(theme.Success).Bold(true),
+		warn:    lipgloss.NewStyle().Foreground(theme.Warning).Bold(true),
+		danger:  lipgloss.NewStyle().Foreground(theme.Danger).Bold(true),
+		muted:   lipgloss.NewStyle().Foreground(theme.Muted),
 	}
 }
 

--- a/internal/cli/report_test.go
+++ b/internal/cli/report_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/2ykwang/mac-cleanup-go/internal/styles"
 	"github.com/2ykwang/mac-cleanup-go/internal/types"
 )
 
@@ -18,7 +19,7 @@ func TestFormatReport_DryRunNoItems(t *testing.T) {
 		Duration:   50 * time.Millisecond,
 	}
 
-	output := FormatReport(report, true)
+	output := FormatReport(report, true, styles.New(true))
 
 	assert.Contains(t, output, "Dry Run Report")
 	assert.Contains(t, output, "Summary")
@@ -48,7 +49,7 @@ func TestFormatReport_IncludesGroups(t *testing.T) {
 		},
 	}
 
-	output := FormatReport(report, false)
+	output := FormatReport(report, false, styles.New(true))
 
 	assert.Contains(t, output, "Cleanup Report")
 	assert.Contains(t, output, "Summary")

--- a/internal/styles/styles.go
+++ b/internal/styles/styles.go
@@ -46,9 +46,9 @@ func New(isDark bool) Styles {
 		Secondary: ld(lipgloss.Color("#0891B2"), lipgloss.Color("#22D3EE")), // cyan-600 / cyan-400
 		Success:   ld(lipgloss.Color("#059669"), lipgloss.Color("#34D399")), // emerald-600 / emerald-400
 		Warning:   ld(lipgloss.Color("#D97706"), lipgloss.Color("#FBBF24")), // amber-600 / amber-400
-		Muted:     ld(lipgloss.Color("#4B5563"), lipgloss.Color("#9CA3AF")), // gray-600 / gray-400
+		Muted:     ld(lipgloss.Color("#4B5563"), lipgloss.Color("#B5B5B5")), // gray-600 / 256-color 250
 		Text:      ld(lipgloss.Color("#111827"), lipgloss.Color("#F9FAFB")), // gray-900 / gray-50
-		Border:    ld(lipgloss.Color("#D1D5DB"), lipgloss.Color("#6B7280")), // gray-300 / gray-500
+		Border:    ld(lipgloss.Color("#D1D5DB"), lipgloss.Color("#909090")), // gray-300 / 256-color 242
 	}
 
 	s.TextStyle = lipgloss.NewStyle().Foreground(s.Text)

--- a/internal/styles/styles.go
+++ b/internal/styles/styles.go
@@ -46,9 +46,9 @@ func New(isDark bool) Styles {
 		Secondary: ld(lipgloss.Color("#0891B2"), lipgloss.Color("#22D3EE")), // cyan-600 / cyan-400
 		Success:   ld(lipgloss.Color("#059669"), lipgloss.Color("#34D399")), // emerald-600 / emerald-400
 		Warning:   ld(lipgloss.Color("#D97706"), lipgloss.Color("#FBBF24")), // amber-600 / amber-400
-		Muted:     ld(lipgloss.Color("#4B5563"), lipgloss.Color("#B5B5B5")), // gray-600 / 256-color 250
+		Muted:     ld(lipgloss.Color("#4B5563"), lipgloss.Color("#A0A0A0")), // gray-600 / 256-color ~247
 		Text:      ld(lipgloss.Color("#111827"), lipgloss.Color("#F9FAFB")), // gray-900 / gray-50
-		Border:    ld(lipgloss.Color("#D1D5DB"), lipgloss.Color("#909090")), // gray-300 / 256-color 242
+		Border:    ld(lipgloss.Color("#D1D5DB"), lipgloss.Color("#7A7A7A")), // gray-300 / 256-color ~243
 	}
 
 	s.TextStyle = lipgloss.NewStyle().Foreground(s.Text)
@@ -56,17 +56,17 @@ func New(isDark bool) Styles {
 	s.SuccessStyle = lipgloss.NewStyle().Foreground(s.Success)
 	s.WarningStyle = lipgloss.NewStyle().Foreground(s.Warning)
 	s.DangerStyle = lipgloss.NewStyle().Foreground(s.Danger)
-	s.SelectedStyle = lipgloss.NewStyle().Foreground(s.Primary).Bold(true)
+	s.SelectedStyle = lipgloss.NewStyle().Foreground(s.Text).Bold(true)
 	s.CursorStyle = lipgloss.NewStyle().Foreground(s.Secondary).Bold(true)
-	s.SizeStyle = lipgloss.NewStyle().Foreground(s.Secondary).Bold(true)
+	s.SizeStyle = lipgloss.NewStyle().Foreground(s.Secondary)
 	s.HelpStyle = lipgloss.NewStyle().Foreground(s.Muted).MarginTop(1)
 	s.HeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(s.Text).Background(s.Primary).Padding(0, 2).MarginBottom(1)
 	s.DividerStyle = lipgloss.NewStyle().Foreground(s.Border)
 	s.ButtonStyle = lipgloss.NewStyle().Padding(0, 2).Border(lipgloss.RoundedBorder()).BorderForeground(s.Border).Foreground(s.Text)
-	s.ButtonActiveStyle = s.ButtonStyle.BorderForeground(s.Primary).Foreground(s.Text).Bold(true)
+	s.ButtonActiveStyle = s.ButtonStyle.BorderForeground(s.Secondary).Foreground(s.Text).Bold(true)
 	s.ButtonDangerStyle = s.ButtonStyle
 	s.ButtonDangerActiveStyle = s.ButtonStyle.BorderForeground(s.Danger).Foreground(s.Danger).Bold(true)
-	s.SectionActiveNameStyle = lipgloss.NewStyle().Bold(true).Foreground(s.Primary)
+	s.SectionActiveNameStyle = lipgloss.NewStyle().Foreground(s.Text).Bold(true)
 
 	return s
 }

--- a/internal/styles/styles.go
+++ b/internal/styles/styles.go
@@ -1,47 +1,93 @@
-// Package styles define shared color and style constants used across TUI and CLI packages.
+// Package styles provides background-aware terminal styles. Construct
+// a bundle with New for the appropriate light or dark variant.
 package styles
 
 import (
+	"image/color"
 	"strings"
 
 	"charm.land/lipgloss/v2"
+
+	"github.com/2ykwang/mac-cleanup-go/internal/types"
 )
 
-// Colors — shared palette for both TUI and CLI output.
-var (
-	ColorPrimary   = lipgloss.Color("#7C3AED")
-	ColorSecondary = lipgloss.Color("#06B6D4")
-	ColorSuccess   = lipgloss.Color("#10B981")
-	ColorWarning   = lipgloss.Color("#F59E0B")
-	ColorDanger    = lipgloss.Color("#EF4444")
-	ColorMuted     = lipgloss.Color("#6B7280")
-	ColorText      = lipgloss.Color("#F9FAFB")
-	ColorBorder    = lipgloss.Color("#374151")
-)
+type Styles struct {
+	// Palette. Primary and Danger are static; the rest adapt to background.
+	Primary, Danger,
+	Secondary, Success, Warning,
+	Muted, Text, Border color.Color
 
-// Styles — common lipgloss styles.
-var (
-	TextStyle               = lipgloss.NewStyle().Foreground(ColorText)
-	MutedStyle              = lipgloss.NewStyle().Foreground(ColorMuted)
-	SuccessStyle            = lipgloss.NewStyle().Foreground(ColorSuccess)
-	WarningStyle            = lipgloss.NewStyle().Foreground(ColorWarning)
-	DangerStyle             = lipgloss.NewStyle().Foreground(ColorDanger)
-	SelectedStyle           = lipgloss.NewStyle().Foreground(ColorPrimary).Bold(true)
-	CursorStyle             = lipgloss.NewStyle().Foreground(ColorSecondary).Bold(true)
-	SizeStyle               = lipgloss.NewStyle().Foreground(ColorSecondary).Bold(true)
-	HelpStyle               = lipgloss.NewStyle().Foreground(ColorMuted).MarginTop(1)
-	HeaderStyle             = lipgloss.NewStyle().Bold(true).Foreground(ColorText).Background(ColorPrimary).Padding(0, 2).MarginBottom(1)
-	DividerStyle            = lipgloss.NewStyle().Foreground(ColorBorder)
-	ButtonStyle             = lipgloss.NewStyle().Padding(0, 2).Border(lipgloss.RoundedBorder()).BorderForeground(ColorBorder).Foreground(ColorText)
-	ButtonActiveStyle       = ButtonStyle.BorderForeground(ColorPrimary).Foreground(ColorText).Bold(true)
-	ButtonDangerStyle       = ButtonStyle
-	ButtonDangerActiveStyle = ButtonStyle.BorderForeground(ColorDanger).Foreground(ColorDanger).Bold(true)
-)
+	// Composed styles.
+	TextStyle               lipgloss.Style
+	MutedStyle              lipgloss.Style
+	SuccessStyle            lipgloss.Style
+	WarningStyle            lipgloss.Style
+	DangerStyle             lipgloss.Style
+	SelectedStyle           lipgloss.Style
+	CursorStyle             lipgloss.Style
+	SizeStyle               lipgloss.Style
+	HelpStyle               lipgloss.Style
+	HeaderStyle             lipgloss.Style
+	DividerStyle            lipgloss.Style
+	ButtonStyle             lipgloss.Style
+	ButtonActiveStyle       lipgloss.Style
+	ButtonDangerStyle       lipgloss.Style
+	ButtonDangerActiveStyle lipgloss.Style
+	SectionActiveNameStyle  lipgloss.Style
+}
+
+// New returns a Styles configured for the given terminal background.
+func New(isDark bool) Styles {
+	ld := lipgloss.LightDark(isDark)
+
+	s := Styles{
+		Primary:   lipgloss.Color("#7C3AED"),
+		Danger:    lipgloss.Color("#EF4444"),
+		Secondary: ld(lipgloss.Color("#0891B2"), lipgloss.Color("#22D3EE")), // cyan-600 / cyan-400
+		Success:   ld(lipgloss.Color("#059669"), lipgloss.Color("#34D399")), // emerald-600 / emerald-400
+		Warning:   ld(lipgloss.Color("#D97706"), lipgloss.Color("#FBBF24")), // amber-600 / amber-400
+		Muted:     ld(lipgloss.Color("#4B5563"), lipgloss.Color("#9CA3AF")), // gray-600 / gray-400
+		Text:      ld(lipgloss.Color("#111827"), lipgloss.Color("#F9FAFB")), // gray-900 / gray-50
+		Border:    ld(lipgloss.Color("#D1D5DB"), lipgloss.Color("#6B7280")), // gray-300 / gray-500
+	}
+
+	s.TextStyle = lipgloss.NewStyle().Foreground(s.Text)
+	s.MutedStyle = lipgloss.NewStyle().Foreground(s.Muted)
+	s.SuccessStyle = lipgloss.NewStyle().Foreground(s.Success)
+	s.WarningStyle = lipgloss.NewStyle().Foreground(s.Warning)
+	s.DangerStyle = lipgloss.NewStyle().Foreground(s.Danger)
+	s.SelectedStyle = lipgloss.NewStyle().Foreground(s.Primary).Bold(true)
+	s.CursorStyle = lipgloss.NewStyle().Foreground(s.Secondary).Bold(true)
+	s.SizeStyle = lipgloss.NewStyle().Foreground(s.Secondary).Bold(true)
+	s.HelpStyle = lipgloss.NewStyle().Foreground(s.Muted).MarginTop(1)
+	s.HeaderStyle = lipgloss.NewStyle().Bold(true).Foreground(s.Text).Background(s.Primary).Padding(0, 2).MarginBottom(1)
+	s.DividerStyle = lipgloss.NewStyle().Foreground(s.Border)
+	s.ButtonStyle = lipgloss.NewStyle().Padding(0, 2).Border(lipgloss.RoundedBorder()).BorderForeground(s.Border).Foreground(s.Text)
+	s.ButtonActiveStyle = s.ButtonStyle.BorderForeground(s.Primary).Foreground(s.Text).Bold(true)
+	s.ButtonDangerStyle = s.ButtonStyle
+	s.ButtonDangerActiveStyle = s.ButtonStyle.BorderForeground(s.Danger).Foreground(s.Danger).Bold(true)
+	s.SectionActiveNameStyle = lipgloss.NewStyle().Bold(true).Foreground(s.Primary)
+
+	return s
+}
 
 // Divider renders a horizontal line of the given width.
-func Divider(width int) string {
+func (s Styles) Divider(width int) string {
 	if width <= 0 {
 		return ""
 	}
-	return DividerStyle.Render(strings.Repeat("─", width))
+	return s.DividerStyle.Render(strings.Repeat("─", width))
+}
+
+func (s Styles) SafetyDot(level types.SafetyLevel) string {
+	switch level {
+	case types.SafetyLevelSafe:
+		return s.SuccessStyle.Render("●")
+	case types.SafetyLevelModerate:
+		return s.WarningStyle.Render("●")
+	case types.SafetyLevelRisky:
+		return s.DangerStyle.Render("●")
+	default:
+		return s.MutedStyle.Render("●")
+	}
 }

--- a/internal/styles/styles_test.go
+++ b/internal/styles/styles_test.go
@@ -1,0 +1,72 @@
+package styles
+
+import (
+	"image/color"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_DarkUsesLightForeground(t *testing.T) {
+	s := New(true)
+
+	r, g, b, _ := s.Text.RGBA()
+
+	assert.True(t, isLight(r, g, b), "Text color should be light on dark background")
+}
+
+func TestNew_LightUsesDarkForeground(t *testing.T) {
+	s := New(false)
+
+	r, g, b, _ := s.Text.RGBA()
+
+	assert.False(t, isLight(r, g, b), "Text color should be dark on light background")
+}
+
+func TestNew_AdaptiveColorsDifferBetweenModes(t *testing.T) {
+	dark := New(true)
+	light := New(false)
+
+	assert.NotEqual(t, snapshot(dark.Border), snapshot(light.Border), "Border must adapt")
+	assert.NotEqual(t, snapshot(dark.Muted), snapshot(light.Muted), "Muted must adapt")
+	assert.NotEqual(t, snapshot(dark.Text), snapshot(light.Text), "Text must adapt")
+	assert.NotEqual(t, snapshot(dark.Secondary), snapshot(light.Secondary), "Secondary must adapt")
+	assert.NotEqual(t, snapshot(dark.Success), snapshot(light.Success), "Success must adapt")
+	assert.NotEqual(t, snapshot(dark.Warning), snapshot(light.Warning), "Warning must adapt")
+}
+
+func TestNew_StylesPickUpThemeColors(t *testing.T) {
+	dark := New(true)
+	light := New(false)
+
+	darkMuted := dark.MutedStyle.GetForeground()
+	lightMuted := light.MutedStyle.GetForeground()
+
+	require.NotNil(t, darkMuted)
+	require.NotNil(t, lightMuted)
+
+	assert.NotEqual(t, snapshot(darkMuted), snapshot(lightMuted),
+		"MutedStyle foreground should differ between dark and light themes")
+}
+
+func TestNew_StaticColorsAreBackgroundIndependent(t *testing.T) {
+	dark := New(true)
+	light := New(false)
+
+	assert.Equal(t, snapshot(dark.Primary), snapshot(light.Primary), "Primary must not change")
+	assert.Equal(t, snapshot(dark.Danger), snapshot(light.Danger), "Danger must not change")
+}
+
+func snapshot(c color.Color) [4]uint32 {
+	r, g, b, a := c.RGBA()
+	return [4]uint32{r, g, b, a}
+}
+
+func isLight(r, g, b uint32) bool {
+	return luma(r, g, b) > 0x7FFF
+}
+
+func luma(r, g, b uint32) uint32 {
+	return (2126*r + 7152*g + 722*b) / 10000
+}

--- a/internal/tui/format.go
+++ b/internal/tui/format.go
@@ -6,8 +6,6 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/2ykwang/mac-cleanup-go/internal/styles"
-	"github.com/2ykwang/mac-cleanup-go/internal/types"
 	"github.com/2ykwang/mac-cleanup-go/internal/utils"
 )
 
@@ -23,8 +21,6 @@ const (
 	// previewPrefixWidth: cursor(2) + checkbox(3) + space(1) + icon(2) + space(1)
 	previewPrefixWidth = 9
 )
-
-var SectionActiveNameStyle = lipgloss.NewStyle().Bold(true).Foreground(styles.ColorPrimary)
 
 func splitColumns(available int, weights, caps []int) []int {
 	cols := make([]int, len(weights))
@@ -160,19 +156,6 @@ func (m *Model) nameSizeColumns(overhead int, allowOverflow bool) (int, int) {
 // Helper functions
 func formatSize(bytes int64) string {
 	return utils.FormatSize(bytes)
-}
-
-func safetyDot(level types.SafetyLevel) string {
-	switch level {
-	case types.SafetyLevelSafe:
-		return styles.SuccessStyle.Render("●")
-	case types.SafetyLevelModerate:
-		return styles.WarningStyle.Render("●")
-	case types.SafetyLevelRisky:
-		return styles.DangerStyle.Render("●")
-	default:
-		return styles.MutedStyle.Render("●")
-	}
 }
 
 // shortenPath truncates path to fit within maxWidth display columns.

--- a/internal/tui/handlers.go
+++ b/internal/tui/handlers.go
@@ -53,6 +53,12 @@ func (m *Model) handleReportKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) handleListKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if m.showHint {
+		if msg.String() == "esc" {
+			m.showHint = false
+		}
+		return m, nil
+	}
 	switch msg.String() {
 	case "?":
 		return m.toggleHelp()
@@ -122,6 +128,8 @@ func (m *Model) handleListKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			}
 			m.initializePreviewSections()
 			m.view = ViewPreview
+		} else {
+			m.showHint = true
 		}
 	}
 	return m, nil

--- a/internal/tui/help_styles.go
+++ b/internal/tui/help_styles.go
@@ -1,0 +1,30 @@
+package tui
+
+import (
+	"charm.land/bubbles/v2/help"
+	"charm.land/lipgloss/v2"
+
+	"github.com/2ykwang/mac-cleanup-go/internal/styles"
+)
+
+// newStyledHelp returns a help.Model whose styles render keys as keycaps
+func newStyledHelp(theme styles.Styles) help.Model {
+	h := help.New()
+	h.Styles = helpStyles(theme)
+	return h
+}
+
+func helpStyles(theme styles.Styles) help.Styles {
+	key := lipgloss.NewStyle().Foreground(theme.Text).Bold(true)
+	muted := lipgloss.NewStyle().Foreground(theme.Muted)
+
+	return help.Styles{
+		Ellipsis:       muted,
+		ShortKey:       key,
+		ShortDesc:      muted,
+		ShortSeparator: muted,
+		FullKey:        key,
+		FullDesc:       muted,
+		FullSeparator:  muted,
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -146,7 +146,8 @@ func (m *Model) View() tea.View {
 			Content: m.renderCentered(func() string {
 				return "Error: " + m.err.Error() + "\n\nPress q to quit."
 			}, maxContentWidth),
-			AltScreen: true,
+			AltScreen:       true,
+			ForegroundColor: m.styles.Text,
 		}
 	}
 
@@ -172,7 +173,7 @@ func (m *Model) View() tea.View {
 		base := lipgloss.NewStyle().Faint(true).Render(output)
 		output = overlayCentered(base, m.helpDialog(), m.width, m.height)
 	}
-	return tea.View{Content: output, AltScreen: true}
+	return tea.View{Content: output, AltScreen: true, ForegroundColor: m.styles.Text}
 }
 
 func (m *Model) renderCentered(render func() string, maxWidth int) string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -50,7 +50,7 @@ func NewModel(cfg *types.Config, currentVersion string) *Model {
 
 	s := spinner.New()
 	s.Spinner = spinner.Dot
-	s.Style = lipgloss.NewStyle().Foreground(theme.Primary)
+	s.Style = lipgloss.NewStyle().Foreground(theme.Muted)
 
 	// Initialize filter input
 	ti := textinput.New()
@@ -171,6 +171,10 @@ func (m *Model) View() tea.View {
 	if m.showHelp {
 		base := lipgloss.NewStyle().Faint(true).Render(output)
 		output = overlayCentered(base, m.helpDialog(), m.width, m.height)
+	}
+	if m.showHint {
+		base := lipgloss.NewStyle().Faint(true).Render(output)
+		output = overlayCentered(base, m.hintDialog(), m.width, m.height)
 	}
 	return tea.View{Content: output, AltScreen: true, ForegroundColor: m.styles.Text}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -42,13 +42,16 @@ type Model struct {
 	cleaningState
 	reportState
 	versionState
+	themeState
 }
 
 // NewModel creates a new model
 func NewModel(cfg *types.Config, currentVersion string) *Model {
+	theme := styles.New(true)
+
 	s := spinner.New()
 	s.Spinner = spinner.Dot
-	s.Style = lipgloss.NewStyle().Foreground(styles.ColorPrimary)
+	s.Style = lipgloss.NewStyle().Foreground(theme.Primary)
 
 	// Initialize filter input
 	ti := textinput.New()
@@ -127,12 +130,13 @@ func NewModel(cfg *types.Config, currentVersion string) *Model {
 		versionState: versionState{
 			currentVersion: currentVersion,
 		},
+		themeState: themeState{styles: theme},
 	}
 }
 
 // Init initializes the model
 func (m *Model) Init() tea.Cmd {
-	return tea.Batch(m.spinner.Tick, m.startScan(), m.checkVersion())
+	return tea.Batch(m.spinner.Tick, m.startScan(), m.checkVersion(), tea.RequestBackgroundColor)
 }
 
 // View renders the UI

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"strings"
 
-	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/progress"
 	"charm.land/bubbles/v2/spinner"
 	"charm.land/bubbles/v2/textinput"
@@ -102,7 +101,7 @@ func NewModel(cfg *types.Config, currentVersion string) *Model {
 		},
 		layoutState: layoutState{
 			view: ViewList,
-			help: help.New(),
+			help: newStyledHelp(theme),
 		},
 		scanState: scanState{
 			scanning:    true,

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -538,12 +538,40 @@ func TestHandleListKey_EnterPreview(t *testing.T) {
 	assert.True(t, m.isSectionCollapsed("cat1"))
 }
 
-func TestHandleListKey_EnterPreview_NoSelection(t *testing.T) {
+func TestHandleListKey_EnterPreview_NoSelection_ShowsHint(t *testing.T) {
 	m := newTestModelWithResults()
 
 	m.handleListKey(tea.KeyPressMsg{Code: tea.KeyEnter})
 
 	assert.Equal(t, ViewList, m.view, "should stay in list view when nothing selected")
+	assert.True(t, m.showHint, "should show hint when enter pressed without selection")
+}
+
+func TestHandleListKey_EnterPreview_WithSelection_DoesNotShowHint(t *testing.T) {
+	m := newTestModelWithResults()
+	m.selected["cat1"] = true
+
+	m.handleListKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	assert.False(t, m.showHint, "hint should not appear when user has a selection")
+}
+
+func TestHandleListKey_HintDismissedByEsc(t *testing.T) {
+	m := newTestModelWithResults()
+	m.showHint = true
+
+	m.handleListKey(tea.KeyPressMsg{Code: tea.KeyEsc})
+
+	assert.False(t, m.showHint, "esc should dismiss hint")
+}
+
+func TestHandleListKey_HintNotDismissedByOtherKeys(t *testing.T) {
+	m := newTestModelWithResults()
+	m.showHint = true
+
+	m.handleListKey(tea.KeyPressMsg{Code: tea.KeyDown})
+
+	assert.True(t, m.showHint, "non-esc key should not dismiss hint")
 }
 
 func TestHandlePreviewKey_Back(t *testing.T) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -963,7 +963,11 @@ func TestRenderSectionLine_ColumnsAligned(t *testing.T) {
 	count1 := fmt.Sprintf("%d files", r1.TotalFileCount)
 	count2 := fmt.Sprintf("%d files", r2.TotalFileCount)
 
-	assert.Equal(t, strings.Index(line1, size1), strings.Index(line2, size2), "size column should start at same position")
+	// Size column is right-aligned, so verify the end position (not start) matches.
+	assert.Equal(t,
+		strings.Index(line1, size1)+len(size1),
+		strings.Index(line2, size2)+len(size2),
+		"size column should end at same position")
 	assert.Equal(t, strings.Index(line1, count1), strings.Index(line2, count2), "count column should start at same position")
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -38,6 +38,7 @@ func newTestModel() *Model {
 	m.scanDoneIDs = make(map[string]bool)
 	m.userConfig = &userconfig.UserConfig{ExcludedPaths: make(map[string][]string)}
 	m.recentDeleted = NewRingBuffer[DeletedItemEntry](defaultRecentItemsCapacity)
+	m.styles = styles.New(true)
 	return m
 }
 
@@ -1236,8 +1237,8 @@ func TestRenderListItem_ManualItemMuted(t *testing.T) {
 	assert.Contains(t, output, "[Manual]")
 	assert.Contains(t, output, "Telegram DB")
 
-	mutedCheckbox := styles.MutedStyle.Render(" - ")
-	assert.Contains(t, output, mutedCheckbox, "manual item checkbox should be rendered with styles.MutedStyle")
+	mutedCheckbox := m.styles.MutedStyle.Render(" - ")
+	assert.Contains(t, output, mutedCheckbox, "manual item checkbox should be rendered with the muted style")
 
 	m.selected[manualResult.Category.ID] = true
 	outputSelected := m.renderListItem(2, manualResult, nameWidth, sizeWidth, countWidth)

--- a/internal/tui/shortcuts.go
+++ b/internal/tui/shortcuts.go
@@ -8,27 +8,31 @@ import (
 
 // ListKeys defines key bindings for list view
 type ListKeys struct {
-	Up     key.Binding
-	Down   key.Binding
-	Select key.Binding
-	Enter  key.Binding
-	Quit   key.Binding
-	Help   key.Binding
+	Up        key.Binding
+	Down      key.Binding
+	Select    key.Binding
+	SelectAll key.Binding
+	ClearAll  key.Binding
+	Enter     key.Binding
+	Quit      key.Binding
+	Help      key.Binding
 }
 
 func (k ListKeys) ShortHelp() []key.Binding {
-	return []key.Binding{k.Up, k.Select, k.Enter, k.Quit, k.Help}
+	return []key.Binding{k.Up, k.Select, k.SelectAll, k.Enter, k.Quit, k.Help}
 }
 
 func (k ListKeys) FullHelp() [][]key.Binding { return nil }
 
 var ListKeyMap = ListKeys{
-	Up:     key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑/k", "up")),
-	Down:   key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
-	Select: key.NewBinding(key.WithKeys("space"), key.WithHelp("space", "select")),
-	Enter:  key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "preview")),
-	Quit:   key.NewBinding(key.WithKeys("q"), key.WithHelp("q", "quit")),
-	Help:   key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+	Up:        key.NewBinding(key.WithKeys("up", "k"), key.WithHelp("↑/k", "up")),
+	Down:      key.NewBinding(key.WithKeys("down", "j"), key.WithHelp("↓/j", "down")),
+	Select:    key.NewBinding(key.WithKeys("space"), key.WithHelp("space", "select")),
+	SelectAll: key.NewBinding(key.WithKeys("a"), key.WithHelp("a/d", "all/none")),
+	ClearAll:  key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "clear")),
+	Enter:     key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "review")),
+	Quit:      key.NewBinding(key.WithKeys("q"), key.WithHelp("q", "quit")),
+	Help:      key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
 }
 
 // PreviewKeys defines key bindings for preview view

--- a/internal/tui/shortcuts_test.go
+++ b/internal/tui/shortcuts_test.go
@@ -44,11 +44,13 @@ func TestFormatFooter_SingleShortcut(t *testing.T) {
 func TestListKeys_ShortHelp_ReturnsExpectedBindings(t *testing.T) {
 	bindings := ListKeyMap.ShortHelp()
 
-	assert.Len(t, bindings, 5)
+	assert.Len(t, bindings, 6)
 	assert.Equal(t, "↑/k", bindings[0].Help().Key)
 	assert.Equal(t, "space", bindings[1].Help().Key)
-	assert.Equal(t, "enter", bindings[2].Help().Key)
-	assert.Equal(t, "q", bindings[3].Help().Key)
+	assert.Equal(t, "a/d", bindings[2].Help().Key)
+	assert.Equal(t, "enter", bindings[3].Help().Key)
+	assert.Equal(t, "q", bindings[4].Help().Key)
+	assert.Equal(t, "?", bindings[5].Help().Key)
 }
 
 // PreviewKeys tests

--- a/internal/tui/state.go
+++ b/internal/tui/state.go
@@ -9,10 +9,15 @@ import (
 	"charm.land/bubbles/v2/textinput"
 
 	"github.com/2ykwang/mac-cleanup-go/internal/cleaner"
+	"github.com/2ykwang/mac-cleanup-go/internal/styles"
 	"github.com/2ykwang/mac-cleanup-go/internal/target"
 	"github.com/2ykwang/mac-cleanup-go/internal/types"
 	"github.com/2ykwang/mac-cleanup-go/internal/userconfig"
 )
+
+type themeState struct {
+	styles styles.Styles
+}
 
 type configState struct {
 	config            *types.Config

--- a/internal/tui/state.go
+++ b/internal/tui/state.go
@@ -49,6 +49,7 @@ type layoutState struct {
 	help          help.Model
 	showHelp      bool
 	helpScroll    int
+	showHint      bool // list view only — set on enter w/o selection, dismissed by esc
 }
 
 type scanState struct {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/2ykwang/mac-cleanup-go/internal/logger"
+	"github.com/2ykwang/mac-cleanup-go/internal/styles"
 	"github.com/2ykwang/mac-cleanup-go/internal/target"
 	"github.com/2ykwang/mac-cleanup-go/internal/types"
 )
@@ -65,6 +66,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case versionCheckMsg:
 		m.latestVersion = msg.latestVersion
 		m.updateAvailable = msg.updateAvailable
+	case tea.BackgroundColorMsg:
+		m.styles = styles.New(msg.IsDark())
 	}
 	return m, nil
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -68,6 +68,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.updateAvailable = msg.updateAvailable
 	case tea.BackgroundColorMsg:
 		m.styles = styles.New(msg.IsDark())
+		m.help.Styles = helpStyles(m.styles)
 	}
 	return m, nil
 }

--- a/internal/tui/view_cleaning.go
+++ b/internal/tui/view_cleaning.go
@@ -4,14 +4,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/2ykwang/mac-cleanup-go/internal/styles"
 	"github.com/2ykwang/mac-cleanup-go/internal/utils"
 )
 
 func (m *Model) viewCleaning() string {
 	var b strings.Builder
 
-	b.WriteString(styles.HeaderStyle.Render("Cleaning..."))
+	b.WriteString(m.styles.HeaderStyle.Render("Cleaning..."))
 	b.WriteString("\n\n")
 
 	rowWidth := m.cleaningRowWidth()
@@ -24,22 +23,22 @@ func (m *Model) viewCleaning() string {
 			// Full success
 			size := fmt.Sprintf("%*s", sizeWidth, utils.FormatSize(cat.freedSpace))
 			b.WriteString(fmt.Sprintf("%s %s %s\n",
-				styles.SuccessStyle.Render("✓"),
+				m.styles.SuccessStyle.Render("✓"),
 				displayName,
-				styles.SizeStyle.Render(size)))
+				m.styles.SizeStyle.Render(size)))
 		} else if cat.cleaned > 0 {
 			// Partial success
 			size := fmt.Sprintf("%*s", sizeWidth, utils.FormatSize(cat.freedSpace))
 			b.WriteString(fmt.Sprintf("%s %s %s\n",
-				styles.WarningStyle.Render("△"),
+				m.styles.WarningStyle.Render("△"),
 				displayName,
-				styles.SizeStyle.Render(size)))
+				m.styles.SizeStyle.Render(size)))
 		} else {
 			// All failed
 			b.WriteString(fmt.Sprintf("%s %s %s\n",
-				styles.DangerStyle.Render("✗"),
+				m.styles.DangerStyle.Render("✗"),
 				displayName,
-				styles.MutedStyle.Render("failed")))
+				m.styles.MutedStyle.Render("failed")))
 		}
 	}
 
@@ -54,14 +53,14 @@ func (m *Model) viewCleaning() string {
 			if len(item) > 45 {
 				item = "..." + item[len(item)-42:]
 			}
-			b.WriteString(styles.MutedStyle.Render(fmt.Sprintf("  └ %s\n", item)))
+			b.WriteString(m.styles.MutedStyle.Render(fmt.Sprintf("  └ %s\n", item)))
 		}
 	}
 
 	// Show recent deletions list
 	if m.recentDeleted.Len() > 0 {
 		b.WriteString("\n")
-		b.WriteString(styles.MutedStyle.Render("Recent:"))
+		b.WriteString(m.styles.MutedStyle.Render("Recent:"))
 		b.WriteString("\n")
 		b.WriteString(m.renderRecentDeleted())
 	}
@@ -77,7 +76,7 @@ func (m *Model) viewCleaning() string {
 			percent = m.cleaningCurrent * 100 / m.cleaningTotal
 		}
 		progress := fmt.Sprintf("%d%% (%d/%d)", percent, m.cleaningCurrent, m.cleaningTotal)
-		b.WriteString(styles.MutedStyle.Render(progress))
+		b.WriteString(m.styles.MutedStyle.Render(progress))
 	}
 
 	return b.String()
@@ -105,9 +104,9 @@ func (m *Model) renderRecentDeleted() string {
 		// Status icon
 		var icon string
 		if entry.Success {
-			icon = styles.SuccessStyle.Render("✓")
+			icon = m.styles.SuccessStyle.Render("✓")
 		} else {
-			icon = styles.DangerStyle.Render("✗")
+			icon = m.styles.DangerStyle.Render("✗")
 		}
 
 		displayPath := shortenPath(entry.Path, nameWidth)
@@ -121,12 +120,12 @@ func (m *Model) renderRecentDeleted() string {
 			b.WriteString(fmt.Sprintf("  %s %s %s\n",
 				icon,
 				displayPath,
-				styles.SizeStyle.Render(size)))
+				m.styles.SizeStyle.Render(size)))
 		} else {
 			b.WriteString(fmt.Sprintf("  %s %s %s\n",
 				icon,
-				styles.MutedStyle.Render(displayPath),
-				styles.MutedStyle.Render(size)))
+				m.styles.MutedStyle.Render(displayPath),
+				m.styles.MutedStyle.Render(size)))
 		}
 	}
 

--- a/internal/tui/view_cleaning_test.go
+++ b/internal/tui/view_cleaning_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/2ykwang/mac-cleanup-go/internal/styles"
 	"github.com/2ykwang/mac-cleanup-go/internal/userconfig"
 )
 
@@ -16,6 +17,7 @@ func newTestModelForViewCleaning() *Model {
 	m.height = 24
 	m.recentDeleted = NewRingBuffer[DeletedItemEntry](defaultRecentItemsCapacity)
 	m.userConfig = &userconfig.UserConfig{ExcludedPaths: make(map[string][]string)}
+	m.styles = styles.New(true)
 	return m
 }
 

--- a/internal/tui/view_cleaning_test.go
+++ b/internal/tui/view_cleaning_test.go
@@ -87,8 +87,8 @@ func TestRenderRecentDeleted_FileSize(t *testing.T) {
 
 	output := m.renderRecentDeleted()
 
-	// utils.FormatSize(1024*1024) returns "1.0 MB"
-	assert.Contains(t, output, "1.0 MB", "should display formatted file size")
+	// utils.FormatSize(1024*1024) returns "1 MB"
+	assert.Contains(t, output, "1 MB", "should display formatted file size")
 }
 
 func TestRenderRecentDeleted_LongPathTruncation(t *testing.T) {

--- a/internal/tui/view_config.go
+++ b/internal/tui/view_config.go
@@ -42,6 +42,8 @@ type ConfigModel struct {
 	showIntro bool
 	status    string
 	err       error
+
+	styles styles.Styles
 }
 
 // NewConfigModel creates a new config TUI model.
@@ -60,6 +62,7 @@ func NewConfigModel(cfg *types.Config) *ConfigModel {
 		items:    make([]configItem, 0),
 		selected: make(map[string]bool),
 		err:      err,
+		styles:   styles.New(true),
 	}
 
 	m.initItems()
@@ -99,7 +102,7 @@ func (m *ConfigModel) initSelection() {
 
 // Init implements tea.Model.
 func (m *ConfigModel) Init() tea.Cmd {
-	return m.startScan()
+	return tea.Batch(m.startScan(), tea.RequestBackgroundColor)
 }
 
 func (m *ConfigModel) startScan() tea.Cmd {
@@ -136,6 +139,8 @@ func (m *ConfigModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+	case tea.BackgroundColorMsg:
+		m.styles = styles.New(msg.IsDark())
 	case configScanResultMsg:
 		for i, item := range m.items {
 			if item.category.ID == msg.categoryID {
@@ -238,21 +243,21 @@ func (m *ConfigModel) viewList() string {
 	nameWidth := max(min(width-listPrefixWidth-sizeWidth-1, colName), 10)
 
 	var header strings.Builder
-	header.WriteString(styles.HeaderStyle.Render("Target Selection") + "\n")
-	header.WriteString(styles.MutedStyle.Render("Select cleanup targets") + "\n")
-	header.WriteString(styles.Divider(clampWidth(width-4, 30)) + "\n")
+	header.WriteString(m.styles.HeaderStyle.Render("Target Selection") + "\n")
+	header.WriteString(m.styles.MutedStyle.Render("Select cleanup targets") + "\n")
+	header.WriteString(m.styles.Divider(clampWidth(width-4, 30)) + "\n")
 	colHeader := fmt.Sprintf("%*s%-*s %*s",
 		listPrefixWidth, "", nameWidth, "Name", sizeWidth, "Size")
-	header.WriteString(styles.MutedStyle.Render(colHeader) + "\n")
+	header.WriteString(m.styles.MutedStyle.Render(colHeader) + "\n")
 	headerStr := header.String()
 
 	var footer strings.Builder
-	footer.WriteString(styles.Divider(clampWidth(width-4, 30)) + "\n")
-	footer.WriteString(styles.MutedStyle.Render(fmt.Sprintf("Selected: %d", m.selectedCount())) + "\n")
+	footer.WriteString(m.styles.Divider(clampWidth(width-4, 30)) + "\n")
+	footer.WriteString(m.styles.MutedStyle.Render(fmt.Sprintf("Selected: %d", m.selectedCount())) + "\n")
 	if m.status != "" {
-		footer.WriteString(styles.WarningStyle.Render(m.status) + "\n")
+		footer.WriteString(m.styles.WarningStyle.Render(m.status) + "\n")
 	}
-	footer.WriteString(styles.HelpStyle.Render(FormatFooter(configShortcuts)))
+	footer.WriteString(m.styles.HelpStyle.Render(FormatFooter(configShortcuts)))
 	footerStr := footer.String()
 
 	visible := m.height - countLines(headerStr) - countLines(footerStr)
@@ -272,7 +277,7 @@ func (m *ConfigModel) viewList() string {
 	b.WriteString(headerStr)
 
 	if total == 0 {
-		b.WriteString(styles.MutedStyle.Render("No available targets found.") + "\n")
+		b.WriteString(m.styles.MutedStyle.Render("No available targets found.") + "\n")
 	} else {
 		end := min(m.scroll+visible, total)
 		for i := m.scroll; i < end; i++ {
@@ -281,7 +286,7 @@ func (m *ConfigModel) viewList() string {
 		}
 		if total > visible+1 {
 			info := fmt.Sprintf("  %d-%d of %d", m.scroll+1, end, total)
-			b.WriteString(styles.MutedStyle.Render(info) + "\n")
+			b.WriteString(m.styles.MutedStyle.Render(info) + "\n")
 		}
 	}
 
@@ -292,33 +297,33 @@ func (m *ConfigModel) viewList() string {
 func (m *ConfigModel) renderItemLine(index int, item configItem, width int) string {
 	cursor := "  "
 	if index == m.cursor {
-		cursor = styles.CursorStyle.Render("▸ ")
+		cursor = m.styles.CursorStyle.Render("▸ ")
 	}
 
-	checkbox := styles.MutedStyle.Render("[ ]")
+	checkbox := m.styles.MutedStyle.Render("[ ]")
 	if item.disabled {
-		checkbox = styles.MutedStyle.Render(" - ")
+		checkbox = m.styles.MutedStyle.Render(" - ")
 	} else if m.selected[item.category.ID] {
-		checkbox = styles.SuccessStyle.Render("[✓]")
+		checkbox = m.styles.SuccessStyle.Render("[✓]")
 	}
 
-	dot := safetyDot(item.category.Safety)
+	dot := m.styles.SafetyDot(item.category.Safety)
 
 	sizeWidth := colSize
 	nameWidth := max(min(width-listPrefixWidth-sizeWidth-1, colName), 10)
 
 	name := padToWidth(truncateToWidth(item.category.Name, nameWidth, false), nameWidth)
 	if item.disabled {
-		name = styles.MutedStyle.Render(name)
+		name = m.styles.MutedStyle.Render(name)
 	}
 
 	var sizeText string
 	if !item.scanned {
-		sizeText = styles.MutedStyle.Render(fmt.Sprintf("%*s", sizeWidth, "..."))
+		sizeText = m.styles.MutedStyle.Render(fmt.Sprintf("%*s", sizeWidth, "..."))
 	} else if item.size > 0 {
-		sizeText = styles.SizeStyle.Render(fmt.Sprintf("%*s", sizeWidth, formatSize(item.size)))
+		sizeText = m.styles.SizeStyle.Render(fmt.Sprintf("%*s", sizeWidth, formatSize(item.size)))
 	} else {
-		sizeText = styles.MutedStyle.Render(fmt.Sprintf("%*s", sizeWidth, "0 B"))
+		sizeText = m.styles.MutedStyle.Render(fmt.Sprintf("%*s", sizeWidth, "0 B"))
 	}
 
 	return fmt.Sprintf("%s%s %s %s %s", cursor, checkbox, dot, name, sizeText)
@@ -365,45 +370,45 @@ func (m *ConfigModel) introDialog() string {
 
 	sectionStyle := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(styles.ColorSecondary)
+		Foreground(m.styles.Secondary)
 
 	var b strings.Builder
 
 	// Title
-	b.WriteString(styles.HeaderStyle.Render("Getting Started"))
+	b.WriteString(m.styles.HeaderStyle.Render("Getting Started"))
 	b.WriteString("\n\n")
 
 	// Description
-	b.WriteString(styles.TextStyle.Render("Configure cleanup targets for CLI mode."))
+	b.WriteString(m.styles.TextStyle.Render("Configure cleanup targets for CLI mode."))
 	b.WriteString("\n")
-	b.WriteString(styles.TextStyle.Render("Selected targets run with ") + styles.SelectedStyle.Render("--clean") + styles.TextStyle.Render(" flag."))
+	b.WriteString(m.styles.TextStyle.Render("Selected targets run with ") + m.styles.SelectedStyle.Render("--clean") + m.styles.TextStyle.Render(" flag."))
 	b.WriteString("\n")
-	b.WriteString(styles.TextStyle.Render("Files are moved to Trash (recoverable)."))
+	b.WriteString(m.styles.TextStyle.Render("Files are moved to Trash (recoverable)."))
 	b.WriteString("\n\n")
 
 	// Section: Target types
 	b.WriteString(sectionStyle.Render("Target Types"))
 	b.WriteString("\n")
-	b.WriteString("  " + safetyDot(types.SafetyLevelSafe) + " Safe")
+	b.WriteString("  " + m.styles.SafetyDot(types.SafetyLevelSafe) + " Safe")
 	b.WriteString("\n")
-	b.WriteString(styles.MutedStyle.Render("    Auto-regenerated caches and logs"))
+	b.WriteString(m.styles.MutedStyle.Render("    Auto-regenerated caches and logs"))
 	b.WriteString("\n")
-	b.WriteString("  " + safetyDot(types.SafetyLevelModerate) + " Moderate")
+	b.WriteString("  " + m.styles.SafetyDot(types.SafetyLevelModerate) + " Moderate")
 	b.WriteString("\n")
-	b.WriteString(styles.MutedStyle.Render("    May require re-download or re-login"))
+	b.WriteString(m.styles.MutedStyle.Render("    May require re-download or re-login"))
 	b.WriteString("\n\n")
 
-	b.WriteString(styles.Divider(contentWidth) + "\n\n")
+	b.WriteString(m.styles.Divider(contentWidth) + "\n\n")
 
 	// Commands
-	infoLabel := lipgloss.NewStyle().Foreground(styles.ColorMuted).Width(10)
-	b.WriteString(infoLabel.Render("Clean") + styles.MutedStyle.Render("mac-cleanup ") + styles.SelectedStyle.Render("--clean"))
+	infoLabel := lipgloss.NewStyle().Foreground(m.styles.Muted).Width(10)
+	b.WriteString(infoLabel.Render("Clean") + m.styles.MutedStyle.Render("mac-cleanup ") + m.styles.SelectedStyle.Render("--clean"))
 	b.WriteString("\n")
-	b.WriteString(infoLabel.Render("Dry run") + styles.MutedStyle.Render("mac-cleanup ") + styles.SelectedStyle.Render("--clean --dry-run"))
+	b.WriteString(infoLabel.Render("Dry run") + m.styles.MutedStyle.Render("mac-cleanup ") + m.styles.SelectedStyle.Render("--clean --dry-run"))
 	b.WriteString("\n\n")
 
 	// Button
-	button := styles.ButtonActiveStyle.Render("Got it")
+	button := m.styles.ButtonActiveStyle.Render("Got it")
 	if contentWidth > 0 {
 		button = lipgloss.PlaceHorizontal(contentWidth, lipgloss.Center, button)
 	}
@@ -411,7 +416,7 @@ func (m *ConfigModel) introDialog() string {
 
 	boxStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(styles.ColorBorder).
+		BorderForeground(m.styles.Border).
 		Padding(1, 2).
 		Width(boxWidth)
 

--- a/internal/tui/view_config.go
+++ b/internal/tui/view_config.go
@@ -221,8 +221,9 @@ func (m *ConfigModel) saveSelection() error {
 func (m *ConfigModel) View() tea.View {
 	if m.err != nil {
 		return tea.View{
-			Content:   "Error: " + m.err.Error() + "\n\nPress q to quit.",
-			AltScreen: true,
+			Content:         "Error: " + m.err.Error() + "\n\nPress q to quit.",
+			AltScreen:       true,
+			ForegroundColor: m.styles.Text,
 		}
 	}
 
@@ -230,7 +231,7 @@ func (m *ConfigModel) View() tea.View {
 	if m.showIntro {
 		content = overlayCentered(content, m.introDialog(), m.width, m.height)
 	}
-	return tea.View{Content: content, AltScreen: true}
+	return tea.View{Content: content, AltScreen: true, ForegroundColor: m.styles.Text}
 }
 
 func (m *ConfigModel) viewList() string {

--- a/internal/tui/view_config_test.go
+++ b/internal/tui/view_config_test.go
@@ -178,5 +178,5 @@ func TestConfigModel_RenderItemLine_ShowsSize(t *testing.T) {
 	m.items[0].size = 1024 * 1024 // 1 MB
 
 	line := m.renderItemLine(0, m.items[0], m.width)
-	assert.Contains(t, line, "1.0 MB")
+	assert.Contains(t, line, "1 MB")
 }

--- a/internal/tui/view_dialogs.go
+++ b/internal/tui/view_dialogs.go
@@ -6,7 +6,6 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/2ykwang/mac-cleanup-go/internal/styles"
 	"github.com/2ykwang/mac-cleanup-go/internal/utils"
 )
 
@@ -37,7 +36,7 @@ func (m *Model) viewGuide() string {
 	var b strings.Builder
 
 	// Title
-	b.WriteString(styles.HeaderStyle.Render(cat.Name))
+	b.WriteString(m.styles.HeaderStyle.Render(cat.Name))
 	b.WriteString("\n\n")
 
 	// Note (warning) - truncate if too long
@@ -46,14 +45,14 @@ func (m *Model) viewGuide() string {
 		if len(note) > contentWidth-4 {
 			note = note[:contentWidth-7] + "..."
 		}
-		b.WriteString(styles.DangerStyle.Render("⚠ " + note))
+		b.WriteString(m.styles.DangerStyle.Render("⚠ " + note))
 		b.WriteString("\n\n")
 	}
 
-	b.WriteString(styles.Divider(contentWidth) + "\n\n")
+	b.WriteString(m.styles.Divider(contentWidth) + "\n\n")
 
 	// Guide (deletion method)
-	b.WriteString(styles.TextStyle.Render("How to delete:"))
+	b.WriteString(m.styles.TextStyle.Render("How to delete:"))
 	b.WriteString("\n")
 	guideText := cat.Guide
 	if guideText == "" {
@@ -61,14 +60,14 @@ func (m *Model) viewGuide() string {
 	}
 	// Render each line of guide text
 	for _, line := range strings.Split(strings.TrimSpace(guideText), "\n") {
-		b.WriteString(styles.MutedStyle.Render(line))
+		b.WriteString(m.styles.MutedStyle.Render(line))
 		b.WriteString("\n")
 	}
 	b.WriteString("\n")
 
 	// Paths with cursor
 	if len(cat.Paths) > 0 {
-		b.WriteString(styles.TextStyle.Render("Paths:"))
+		b.WriteString(m.styles.TextStyle.Render("Paths:"))
 		b.WriteString("\n")
 		for i, path := range cat.Paths {
 			// Truncate long paths from the beginning
@@ -78,24 +77,24 @@ func (m *Model) viewGuide() string {
 			}
 
 			if i == m.guidePathIndex {
-				b.WriteString(styles.CursorStyle.Render("▸ ") + styles.MutedStyle.Render(displayPath))
+				b.WriteString(m.styles.CursorStyle.Render("▸ ") + m.styles.MutedStyle.Render(displayPath))
 			} else {
-				b.WriteString("  " + styles.MutedStyle.Render(displayPath))
+				b.WriteString("  " + m.styles.MutedStyle.Render(displayPath))
 			}
 			b.WriteString("\n")
 		}
 		b.WriteString("\n")
 	}
 
-	b.WriteString(styles.Divider(contentWidth) + "\n\n")
+	b.WriteString(m.styles.Divider(contentWidth) + "\n\n")
 
 	// Key hints
-	b.WriteString(styles.HelpStyle.Render("↑↓ Select • o Open • Esc Close"))
+	b.WriteString(m.styles.HelpStyle.Render("↑↓ Select • o Open • Esc Close"))
 
 	// Create a fixed-width box
 	boxStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(styles.ColorBorder).
+		BorderForeground(m.styles.Border).
 		Padding(1, 2).
 		Width(boxWidth)
 
@@ -145,27 +144,27 @@ func (m *Model) confirmDialog() string {
 		var head []string
 		var tail []string
 
-		head = append(head, styles.HeaderStyle.Render("Confirm Deletion"))
+		head = append(head, m.styles.HeaderStyle.Render("Confirm Deletion"))
 		if !compact {
 			head = append(head, "")
 		}
-		head = append(head, styles.SuccessStyle.Render("Files will be moved to Trash"))
+		head = append(head, m.styles.SuccessStyle.Render("Files will be moved to Trash"))
 		if !compact {
 			head = append(head, "")
 		}
 		if contentWidth > 0 && !compact {
-			head = append(head, styles.Divider(contentWidth), "")
+			head = append(head, m.styles.Divider(contentWidth), "")
 		}
 		head = append(head, fmt.Sprintf("Total %s will be deleted.",
-			styles.DangerStyle.Render(formatSize(m.getSelectedSize()))))
+			m.styles.DangerStyle.Render(formatSize(m.getSelectedSize()))))
 		if !compact {
 			head = append(head, "")
 		}
 
 		if contentWidth > 0 && !compact {
-			tail = append(tail, styles.Divider(contentWidth), "")
+			tail = append(tail, m.styles.Divider(contentWidth), "")
 		}
-		tail = append(tail, styles.MutedStyle.Render("Items can be recovered from Trash"))
+		tail = append(tail, m.styles.MutedStyle.Render("Items can be recovered from Trash"))
 		if !compact {
 			tail = append(tail, "")
 		}
@@ -219,7 +218,7 @@ func (m *Model) confirmDialog() string {
 
 		for i := start; i < end; i++ {
 			r := selected[i]
-			dot := safetyDot(r.Category.Safety)
+			dot := m.styles.SafetyDot(r.Category.Safety)
 			effectiveSize := m.getEffectiveSize(r)
 			size := fmt.Sprintf("%*s", sizeWidth, utils.FormatSize(effectiveSize))
 			name := padToWidth(truncateToWidth(r.Category.Name, nameWidth, false), nameWidth)
@@ -239,14 +238,14 @@ func (m *Model) confirmDialog() string {
 		if contentWidth > 0 {
 			info = truncateToWidth(info, contentWidth, false)
 		}
-		lines = append(lines, styles.MutedStyle.Render(info))
+		lines = append(lines, m.styles.MutedStyle.Render(info))
 	}
 	lines = append(lines, tail...)
 	content := strings.Join(lines, "\n")
 
 	boxStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(styles.ColorBorder).
+		BorderForeground(m.styles.Border).
 		Padding(1, 2).
 		Width(boxWidth)
 
@@ -254,13 +253,13 @@ func (m *Model) confirmDialog() string {
 }
 
 func (m *Model) confirmButtons() string {
-	cancelStyle := styles.ButtonStyle
+	cancelStyle := m.styles.ButtonStyle
 	if m.confirmChoice == confirmCancel {
-		cancelStyle = styles.ButtonActiveStyle
+		cancelStyle = m.styles.ButtonActiveStyle
 	}
-	deleteStyle := styles.ButtonDangerStyle
+	deleteStyle := m.styles.ButtonDangerStyle
 	if m.confirmChoice == confirmDelete {
-		deleteStyle = styles.ButtonDangerActiveStyle
+		deleteStyle = m.styles.ButtonDangerActiveStyle
 	}
 
 	cancel := cancelStyle.Render("Cancel")

--- a/internal/tui/view_dialogs.go
+++ b/internal/tui/view_dialogs.go
@@ -9,6 +9,30 @@ import (
 	"github.com/2ykwang/mac-cleanup-go/internal/utils"
 )
 
+// Hint dialog (shown when user presses enter without any selection)
+
+func (m *Model) hintDialog() string {
+	boxWidth := min(56, m.width-4)
+	if boxWidth < 24 {
+		boxWidth = m.width
+	}
+
+	var b strings.Builder
+	b.WriteString(m.styles.HeaderStyle.Render("Nothing selected yet"))
+	b.WriteString("\n\n")
+	b.WriteString(m.styles.TextStyle.Render("Use [space] or [a] to choose what to clean."))
+	b.WriteString("\n\n")
+	b.WriteString(m.styles.HelpStyle.Render("Press esc to dismiss"))
+
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(m.styles.Border).
+		Padding(1, 2).
+		Width(boxWidth)
+
+	return boxStyle.Render(b.String())
+}
+
 // Confirm dialog view
 
 func (m *Model) viewConfirm() string {

--- a/internal/tui/view_help.go
+++ b/internal/tui/view_help.go
@@ -6,8 +6,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-
-	"github.com/2ykwang/mac-cleanup-go/internal/styles"
 )
 
 const githubURL = "https://github.com/2ykwang/mac-cleanup-go"
@@ -15,8 +13,8 @@ const githubURL = "https://github.com/2ykwang/mac-cleanup-go"
 func (m *Model) helpContent(contentWidth int) string {
 	section := lipgloss.NewStyle().
 		Bold(true).
-		Foreground(styles.ColorSecondary)
-	keyStyle := lipgloss.NewStyle().Foreground(styles.ColorSecondary)
+		Foreground(m.styles.Secondary)
+	keyStyle := lipgloss.NewStyle().Foreground(m.styles.Secondary)
 	colStyle := lipgloss.NewStyle().Width(14)
 
 	styledKey := func(s string) string {
@@ -28,28 +26,28 @@ func (m *Model) helpContent(contentWidth int) string {
 		for i, p := range parts {
 			rendered[i] = keyStyle.Render(p)
 		}
-		return strings.Join(rendered, styles.MutedStyle.Render(" / "))
+		return strings.Join(rendered, m.styles.MutedStyle.Render(" / "))
 	}
 
 	writeRow := func(b *strings.Builder, key, desc string) {
-		b.WriteString("  " + colStyle.Render(styledKey(key)) + styles.MutedStyle.Render(desc) + "\n")
+		b.WriteString("  " + colStyle.Render(styledKey(key)) + m.styles.MutedStyle.Render(desc) + "\n")
 	}
 
 	var b strings.Builder
 
-	muted := styles.MutedStyle
-	div := styles.Divider(contentWidth)
+	muted := m.styles.MutedStyle
+	div := m.styles.Divider(contentWidth)
 
 	// Title
-	b.WriteString(styles.HeaderStyle.Render("Help"))
+	b.WriteString(m.styles.HeaderStyle.Render("Help"))
 	b.WriteString("\n" + div + "\n\n")
 
 	// Overview
 	b.WriteString(section.Render("Overview"))
 	b.WriteString("\n")
-	b.WriteString(styles.TextStyle.Render("Scans and removes macOS system caches, app logs, old"))
+	b.WriteString(m.styles.TextStyle.Render("Scans and removes macOS system caches, app logs, old"))
 	b.WriteString("\n")
-	b.WriteString(styles.TextStyle.Render("downloads, and dev tool leftovers to free disk space."))
+	b.WriteString(m.styles.TextStyle.Render("downloads, and dev tool leftovers to free disk space."))
 	b.WriteString("\n")
 	b.WriteString(muted.Render("Files are moved to Trash by default — always recoverable."))
 	b.WriteString("\n")
@@ -96,7 +94,7 @@ func (m *Model) helpContent(contentWidth int) string {
 	b.WriteString("\n")
 	b.WriteString("  • " + keyStyle.Render("space") + muted.Render(" on manual item → opens cleanup guide") + "\n")
 	b.WriteString("  • " + keyStyle.Render("/") + muted.Render(" in preview → search files by name") + "\n")
-	b.WriteString("  • " + styles.DangerStyle.Render("Risky") + muted.Render(" items are auto-excluded for safety") + "\n")
+	b.WriteString("  • " + m.styles.DangerStyle.Render("Risky") + muted.Render(" items are auto-excluded for safety") + "\n")
 	b.WriteString("\n")
 
 	// GitHub
@@ -157,11 +155,11 @@ func (m *Model) helpDialog() string {
 	if scrollable {
 		footer = "esc close  ↑↓ scroll  o github"
 	}
-	visible += "\n" + styles.MutedStyle.Render(footer)
+	visible += "\n" + m.styles.MutedStyle.Render(footer)
 
 	boxStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
-		BorderForeground(styles.ColorBorder).
+		BorderForeground(m.styles.Border).
 		Padding(1, 2).
 		Width(boxWidth)
 

--- a/internal/tui/view_list.go
+++ b/internal/tui/view_list.go
@@ -278,8 +278,6 @@ func (m *Model) renderListItem(idx int, r *types.ScanResult, nameWidth, sizeWidt
 	name = padToWidth(truncateToWidth(name, nameWidth, false), nameWidth)
 	if isManual {
 		name = m.styles.MutedStyle.Render(name)
-	} else if isCurrent {
-		name = m.styles.SelectedStyle.Render(name)
 	}
 
 	sizeText := utils.FormatSize(r.TotalSize)
@@ -376,7 +374,7 @@ func (m *Model) renderListSidePanel(width int) string {
 		b.WriteString(m.renderSelectedMiniList(width))
 		b.WriteString("\n")
 	}
-	b.WriteString(m.styles.Divider(min(width-2, 30)))
+	b.WriteString(m.styles.Divider(min(width-4, 30)))
 	return b.String()
 }
 
@@ -386,7 +384,7 @@ func (m *Model) renderSelectedMiniList(width int) string {
 		return ""
 	}
 
-	contentWidth := width - 2
+	contentWidth := width - 4
 	if contentWidth < 10 {
 		contentWidth = 10
 	}

--- a/internal/tui/view_list.go
+++ b/internal/tui/view_list.go
@@ -7,7 +7,6 @@ import (
 
 	"charm.land/lipgloss/v2"
 
-	"github.com/2ykwang/mac-cleanup-go/internal/styles"
 	"github.com/2ykwang/mac-cleanup-go/internal/types"
 	"github.com/2ykwang/mac-cleanup-go/internal/utils"
 )
@@ -59,7 +58,7 @@ func (m *Model) getGroupStats() []GroupStat {
 }
 
 // formatGroupStats formats group statistics as a single line string
-func formatGroupStats(stats []GroupStat) string {
+func (m *Model) formatGroupStats(stats []GroupStat) string {
 	if len(stats) == 0 {
 		return ""
 	}
@@ -68,7 +67,7 @@ func formatGroupStats(stats []GroupStat) string {
 	for _, s := range stats {
 		parts = append(parts, fmt.Sprintf("%s: %s", s.Name, formatSize(s.Size)))
 	}
-	return styles.MutedStyle.Render(strings.Join(parts, "  "))
+	return m.styles.MutedStyle.Render(strings.Join(parts, "  "))
 }
 
 func (m *Model) pendingScanNames() string {
@@ -94,14 +93,14 @@ func (m *Model) pendingScanNames() string {
 func (m *Model) listHeader(showSummary bool) string {
 	var b strings.Builder
 
-	b.WriteString(styles.HeaderStyle.Render("Mac Cleanup"))
+	b.WriteString(m.styles.HeaderStyle.Render("Mac Cleanup"))
 	b.WriteString("\n")
 	if m.scanning {
 		b.WriteString(fmt.Sprintf("%s Scanning...  %s\n",
 			m.spinner.View(),
-			styles.MutedStyle.Render(fmt.Sprintf("%d/%d", m.scanCompleted, m.scanTotal))))
+			m.styles.MutedStyle.Render(fmt.Sprintf("%d/%d", m.scanCompleted, m.scanTotal))))
 		if pending := m.pendingScanNames(); pending != "" {
-			b.WriteString(styles.MutedStyle.Render(fmt.Sprintf("  └ %s", pending)))
+			b.WriteString(m.styles.MutedStyle.Render(fmt.Sprintf("  └ %s", pending)))
 			b.WriteString("\n")
 		}
 	}
@@ -110,42 +109,42 @@ func (m *Model) listHeader(showSummary bool) string {
 	if m.updateAvailable && m.latestVersion != "" {
 		updateMsg := fmt.Sprintf("[↑] Update available: %s → %s (run with --update)",
 			m.currentVersion, m.latestVersion)
-		b.WriteString(styles.SuccessStyle.Render(updateMsg))
+		b.WriteString(m.styles.SuccessStyle.Render(updateMsg))
 		b.WriteString("\n")
 	}
 
 	// Permission warning
 	if !m.hasFullDiskAccess {
-		b.WriteString(styles.WarningStyle.Render("[!] Limited access: Grant Full Disk Access in System Settings for complete scan"))
+		b.WriteString(m.styles.WarningStyle.Render("[!] Limited access: Grant Full Disk Access in System Settings for complete scan"))
 		b.WriteString("\n")
 	}
 	b.WriteString("\n")
 
 	// Legend
 	b.WriteString(fmt.Sprintf("%s Safe      %s\n",
-		styles.SuccessStyle.Render("●"), styles.MutedStyle.Render("Auto-regenerated caches")))
+		m.styles.SuccessStyle.Render("●"), m.styles.MutedStyle.Render("Auto-regenerated caches")))
 	b.WriteString(fmt.Sprintf("%s Moderate  %s\n",
-		styles.WarningStyle.Render("●"), styles.MutedStyle.Render("May need re-download or re-login")))
+		m.styles.WarningStyle.Render("●"), m.styles.MutedStyle.Render("May need re-download or re-login")))
 	b.WriteString(fmt.Sprintf("%s Risky     %s\n",
-		styles.DangerStyle.Render("●"), styles.MutedStyle.Render("May contain important data")))
+		m.styles.DangerStyle.Render("●"), m.styles.MutedStyle.Render("May contain important data")))
 	b.WriteString("\n")
 
 	// Summary
 	if showSummary {
-		summary := fmt.Sprintf("Available: %s", styles.SizeStyle.Render(formatSize(m.getAvailableSize())))
+		summary := fmt.Sprintf("Available: %s", m.styles.SizeStyle.Render(formatSize(m.getAvailableSize())))
 		if m.hasSelection() {
 			summary += fmt.Sprintf("  │  Selected: %s (%d)",
-				styles.SizeStyle.Render(formatSize(m.getSelectedSize())), m.getSelectedCount())
+				m.styles.SizeStyle.Render(formatSize(m.getSelectedSize())), m.getSelectedCount())
 		}
 		b.WriteString(summary + "\n")
 	}
 
 	// Group statistics
 	if stats := m.getGroupStats(); len(stats) > 0 {
-		b.WriteString(formatGroupStats(stats) + "\n")
+		b.WriteString(m.formatGroupStats(stats) + "\n")
 	}
 
-	b.WriteString(styles.Divider(60) + "\n")
+	b.WriteString(m.styles.Divider(60) + "\n")
 
 	return b.String()
 }
@@ -155,14 +154,14 @@ func (m *Model) listFooter(includeHelp bool) string {
 
 	// Show scan warnings after scan completes
 	if !m.scanning && len(m.scanErrors) > 0 {
-		b.WriteString(styles.WarningStyle.Render("[!] Scan warnings:"))
+		b.WriteString(m.styles.WarningStyle.Render("[!] Scan warnings:"))
 		b.WriteString("\n")
 		for _, err := range m.scanErrors {
 			errMsg := err.Error
 			if len(errMsg) > 50 {
 				errMsg = errMsg[:47] + "..."
 			}
-			b.WriteString(styles.MutedStyle.Render(fmt.Sprintf("    %s: %s", err.CategoryName, errMsg)))
+			b.WriteString(m.styles.MutedStyle.Render(fmt.Sprintf("    %s: %s", err.CategoryName, errMsg)))
 			b.WriteString("\n")
 		}
 	}
@@ -234,7 +233,7 @@ func (m *Model) viewList() string {
 			Width(sideWidth).
 			Height(sideHeight).
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(styles.ColorBorder).
+			BorderForeground(m.styles.Border).
 			Padding(0, 1)
 		spacer := strings.Repeat(" ", gapWidth)
 		listContent = lipgloss.JoinHorizontal(lipgloss.Top, listStyle.Render(listContent), spacer, sideStyle.Render(sideContent))
@@ -256,18 +255,18 @@ func (m *Model) renderListItem(idx int, r *types.ScanResult, nameWidth, sizeWidt
 
 	cursor := "  "
 	if isCurrent {
-		cursor = styles.CursorStyle.Render("▸ ")
+		cursor = m.styles.CursorStyle.Render("▸ ")
 	}
 
 	checkbox := "[ ]"
 	if isManual {
 		// Manual items cannot be selected - always show muted unchecked box
-		checkbox = styles.MutedStyle.Render(" - ")
+		checkbox = m.styles.MutedStyle.Render(" - ")
 	} else if m.selected[r.Category.ID] {
-		checkbox = styles.SuccessStyle.Render("[✓]")
+		checkbox = m.styles.SuccessStyle.Render("[✓]")
 	}
 
-	dot := safetyDot(r.Category.Safety)
+	dot := m.styles.SafetyDot(r.Category.Safety)
 
 	name := r.Category.Name
 
@@ -278,9 +277,9 @@ func (m *Model) renderListItem(idx int, r *types.ScanResult, nameWidth, sizeWidt
 	// Truncate and pad using display width for consistent alignment
 	name = padToWidth(truncateToWidth(name, nameWidth, false), nameWidth)
 	if isManual {
-		name = styles.MutedStyle.Render(name)
+		name = m.styles.MutedStyle.Render(name)
 	} else if isCurrent {
-		name = styles.SelectedStyle.Render(name)
+		name = m.styles.SelectedStyle.Render(name)
 	}
 
 	sizeText := utils.FormatSize(r.TotalSize)
@@ -294,11 +293,11 @@ func (m *Model) renderListItem(idx int, r *types.ScanResult, nameWidth, sizeWidt
 	count := fmt.Sprintf("%*s", countWidth, countText)
 
 	if isManual {
-		size = styles.MutedStyle.Render(size)
-		count = styles.MutedStyle.Render(count)
+		size = m.styles.MutedStyle.Render(size)
+		count = m.styles.MutedStyle.Render(count)
 	} else {
-		size = styles.SizeStyle.Render(size)
-		count = styles.MutedStyle.Render(count)
+		size = m.styles.SizeStyle.Render(size)
+		count = m.styles.MutedStyle.Render(count)
 	}
 
 	return fmt.Sprintf("%s%s %s %s %s %s\n",
@@ -314,9 +313,9 @@ func (m *Model) renderListBody(visible int) string {
 
 	if len(m.results) == 0 {
 		if m.scanning {
-			b.WriteString(styles.MutedStyle.Render("Scanning..."))
+			b.WriteString(m.styles.MutedStyle.Render("Scanning..."))
 		} else {
-			b.WriteString(styles.MutedStyle.Render("No items to clean."))
+			b.WriteString(m.styles.MutedStyle.Render("No items to clean."))
 		}
 		b.WriteString("\n")
 		return b.String()
@@ -328,7 +327,7 @@ func (m *Model) renderListBody(visible int) string {
 		colHeader := fmt.Sprintf("%*s%-*s %*s %*s",
 			listPrefixWidth, "",
 			nameWidth, "Name", sizeWidth, "Size", countWidth, "Count")
-		b.WriteString(styles.MutedStyle.Render(colHeader) + "\n")
+		b.WriteString(m.styles.MutedStyle.Render(colHeader) + "\n")
 		linesRemaining--
 	}
 
@@ -352,7 +351,7 @@ func (m *Model) renderListBody(visible int) string {
 	}
 
 	if showPager {
-		b.WriteString(styles.MutedStyle.Render(fmt.Sprintf("\n  [%d/%d]", m.cursor+1, len(m.results))))
+		b.WriteString(m.styles.MutedStyle.Render(fmt.Sprintf("\n  [%d/%d]", m.cursor+1, len(m.results))))
 	}
 	return b.String()
 }
@@ -360,24 +359,24 @@ func (m *Model) renderListBody(visible int) string {
 func (m *Model) renderListSidePanel(width int) string {
 	var b strings.Builder
 
-	b.WriteString(styles.HeaderStyle.Render("Summary"))
+	b.WriteString(m.styles.HeaderStyle.Render("Summary"))
 	b.WriteString("\n")
-	b.WriteString(fmt.Sprintf("%s %s", styles.MutedStyle.Render("Available:"), styles.SizeStyle.Render(formatSize(m.getAvailableSize()))))
+	b.WriteString(fmt.Sprintf("%s %s", m.styles.MutedStyle.Render("Available:"), m.styles.SizeStyle.Render(formatSize(m.getAvailableSize()))))
 	b.WriteString("\n")
 	b.WriteString(fmt.Sprintf("%s %s (%s)",
-		styles.MutedStyle.Render("Selected:"),
-		styles.SizeStyle.Render(formatSize(m.getSelectedSize())),
-		styles.TextStyle.Render(fmt.Sprintf("%d", m.getSelectedCount())),
+		m.styles.MutedStyle.Render("Selected:"),
+		m.styles.SizeStyle.Render(formatSize(m.getSelectedSize())),
+		m.styles.TextStyle.Render(fmt.Sprintf("%d", m.getSelectedCount())),
 	))
 	b.WriteString("\n")
 	if m.hasSelection() {
 		b.WriteString("\n")
-		b.WriteString(styles.MutedStyle.Render("Selected Items"))
+		b.WriteString(m.styles.MutedStyle.Render("Selected Items"))
 		b.WriteString("\n")
 		b.WriteString(m.renderSelectedMiniList(width))
 		b.WriteString("\n")
 	}
-	b.WriteString(styles.Divider(min(width-2, 30)))
+	b.WriteString(m.styles.Divider(min(width-2, 30)))
 	return b.String()
 }
 
@@ -405,12 +404,12 @@ func (m *Model) renderSelectedMiniList(width int) string {
 		}
 		name := truncateToWidth(r.Category.Name, nameWidth, false)
 		name = padToWidth(name, nameWidth)
-		dot := safetyDot(r.Category.Safety)
-		b.WriteString(fmt.Sprintf("%s %s %s\n", dot, name, styles.SizeStyle.Render(sizeStr)))
+		dot := m.styles.SafetyDot(r.Category.Safety)
+		b.WriteString(fmt.Sprintf("%s %s %s\n", dot, name, m.styles.SizeStyle.Render(sizeStr)))
 	}
 
 	if len(selected) > limit {
-		b.WriteString(styles.MutedStyle.Render(fmt.Sprintf("+%d more", len(selected)-limit)))
+		b.WriteString(m.styles.MutedStyle.Render(fmt.Sprintf("+%d more", len(selected)-limit)))
 	}
 
 	return strings.TrimRight(b.String(), "\n")

--- a/internal/tui/view_preview.go
+++ b/internal/tui/view_preview.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/2ykwang/mac-cleanup-go/internal/styles"
 	"github.com/2ykwang/mac-cleanup-go/internal/types"
 	"github.com/2ykwang/mac-cleanup-go/internal/utils"
 )
@@ -195,14 +194,14 @@ func (m *Model) readDirectory(path string) []types.CleanableItem {
 func (m *Model) previewHeader() string {
 	var b strings.Builder
 
-	b.WriteString(styles.HeaderStyle.Render("Cleanup Preview"))
+	b.WriteString(m.styles.HeaderStyle.Render("Cleanup Preview"))
 	b.WriteString("\n\n")
 
 	b.WriteString(fmt.Sprintf("Selected: %d  │  Estimated: %s  │  Sort: %s\n",
-		m.getSelectedCount(), styles.SizeStyle.Render(formatSize(m.getSelectedSize())), m.sortOrder.Label()))
+		m.getSelectedCount(), m.styles.SizeStyle.Render(formatSize(m.getSelectedSize())), m.sortOrder.Label()))
 	b.WriteString("\n")
-	b.WriteString(styles.MutedStyle.Render("Next: press ") + styles.SelectedStyle.Render("Y") + styles.MutedStyle.Render(" to open delete confirmation") + "\n")
-	b.WriteString(styles.Divider(60) + "\n")
+	b.WriteString(m.styles.MutedStyle.Render("Next: press ") + m.styles.SelectedStyle.Render("Y") + m.styles.MutedStyle.Render(" to open delete confirmation") + "\n")
+	b.WriteString(m.styles.Divider(60) + "\n")
 
 	return b.String()
 }
@@ -213,21 +212,21 @@ func (m *Model) previewFooter(selected []*types.ScanResult) string {
 	// Warning for risky items
 	for _, r := range selected {
 		if r.Category.Safety == types.SafetyLevelRisky {
-			b.WriteString("\n" + styles.DangerStyle.Render("Warning: Risky items included"))
+			b.WriteString("\n" + m.styles.DangerStyle.Render("Warning: Risky items included"))
 			break
 		}
 	}
 
 	// Status message (e.g., error messages)
 	if m.statusMessage != "" {
-		b.WriteString("\n" + styles.WarningStyle.Render(m.statusMessage))
+		b.WriteString("\n" + m.styles.WarningStyle.Render(m.statusMessage))
 	}
 
 	b.WriteString("\n\n")
 
 	// Context-specific footer for filter mode
 	if m.filterState == FilterTyping {
-		b.WriteString(styles.HelpStyle.Render(FormatFooter(FilterTypingShortcuts)))
+		b.WriteString(m.styles.HelpStyle.Render(FormatFooter(FilterTypingShortcuts)))
 	} else {
 		b.WriteString(m.help.View(PreviewKeyMap))
 	}
@@ -240,7 +239,7 @@ func (m *Model) renderSectionLine(r *types.ScanResult, isCurrentSection bool, is
 
 	cursor := "  "
 	if isFocused {
-		cursor = styles.CursorStyle.Render("▸ ")
+		cursor = m.styles.CursorStyle.Render("▸ ")
 	}
 
 	indicator := "▶"
@@ -248,14 +247,14 @@ func (m *Model) renderSectionLine(r *types.ScanResult, isCurrentSection bool, is
 		indicator = "▼"
 	}
 	if isCurrentSection {
-		indicator = styles.CursorStyle.Render(indicator)
+		indicator = m.styles.CursorStyle.Render(indicator)
 	} else {
-		indicator = styles.MutedStyle.Render(indicator)
+		indicator = m.styles.MutedStyle.Render(indicator)
 	}
 
 	name := padToWidth(truncateToWidth(r.Category.Name, nameWidth, false), nameWidth)
 	if isCurrentSection {
-		name = SectionActiveNameStyle.Render(name)
+		name = m.styles.SectionActiveNameStyle.Render(name)
 	}
 
 	badgeText := ""
@@ -271,20 +270,20 @@ func (m *Model) renderSectionLine(r *types.ScanResult, isCurrentSection bool, is
 		badgeText += " [Manual]"
 	}
 	badgeText = padToWidth(truncateToWidth(badgeText, badgeWidth, false), badgeWidth)
-	badge := styles.MutedStyle.Render(badgeText)
+	badge := m.styles.MutedStyle.Render(badgeText)
 	switch r.Category.Safety {
 	case types.SafetyLevelSafe:
-		badge = styles.SuccessStyle.Render(badgeText)
+		badge = m.styles.SuccessStyle.Render(badgeText)
 	case types.SafetyLevelModerate:
-		badge = styles.WarningStyle.Render(badgeText)
+		badge = m.styles.WarningStyle.Render(badgeText)
 	case types.SafetyLevelRisky:
-		badge = styles.DangerStyle.Render(badgeText)
+		badge = m.styles.DangerStyle.Render(badgeText)
 	}
 
 	size := fmt.Sprintf("%*s", sizeWidth, formatSize(m.getEffectiveSize(r)))
 	count := fmt.Sprintf("%*s", countWidth, fmt.Sprintf("%d", r.TotalFileCount))
 
-	return fmt.Sprintf("%s%s %s %s %s %s", cursor, indicator, name, badge, styles.SizeStyle.Render(size), styles.MutedStyle.Render(count))
+	return fmt.Sprintf("%s%s %s %s %s %s", cursor, indicator, name, badge, m.styles.SizeStyle.Render(size), m.styles.MutedStyle.Render(count))
 }
 
 func (m *Model) previewSectionColumnWidths() (int, int, int, int) {
@@ -300,7 +299,7 @@ func (m *Model) renderSectionColumnsHeader() string {
 	badge := padToWidth("Risk/Mode", badgeWidth)
 	size := fmt.Sprintf("%*s", sizeWidth, "Size")
 	count := fmt.Sprintf("%*s", countWidth, "Files")
-	return styles.MutedStyle.Render(fmt.Sprintf("    %s %s %s %s", name, badge, size, count))
+	return m.styles.MutedStyle.Render(fmt.Sprintf("    %s %s %s %s", name, badge, size, count))
 }
 
 // itemRowOpts holds parameters for rendering a single item row.
@@ -321,18 +320,18 @@ func (m *Model) renderItemRow(opts itemRowOpts) string {
 
 	cursor := "  "
 	if opts.isCurrent {
-		cursor = styles.CursorStyle.Render("▸ ")
+		cursor = m.styles.CursorStyle.Render("▸ ")
 	}
 
 	checkbox := ""
 	if opts.showCheck {
 		switch {
 		case opts.isLocked:
-			checkbox = styles.MutedStyle.Render(" - ")
+			checkbox = m.styles.MutedStyle.Render(" - ")
 		case opts.isExcluded:
-			checkbox = styles.MutedStyle.Render("[ ]")
+			checkbox = m.styles.MutedStyle.Render("[ ]")
 		default:
-			checkbox = styles.SuccessStyle.Render("[x]")
+			checkbox = m.styles.SuccessStyle.Render("[x]")
 		}
 		checkbox += " "
 	}
@@ -344,7 +343,7 @@ func (m *Model) renderItemRow(opts itemRowOpts) string {
 	if opts.showCheck {
 		icon = padToWidth(icon, previewIconWidth)
 		if opts.isLocked {
-			icon = styles.MutedStyle.Render(icon)
+			icon = m.styles.MutedStyle.Render(icon)
 		}
 	}
 
@@ -366,19 +365,19 @@ func (m *Model) renderItemRow(opts itemRowOpts) string {
 
 	switch {
 	case opts.isLocked || opts.isExcluded:
-		paddedName = styles.MutedStyle.Render(paddedName)
+		paddedName = m.styles.MutedStyle.Render(paddedName)
 	case opts.isCurrent:
-		paddedName = styles.SelectedStyle.Render(paddedName)
+		paddedName = m.styles.SelectedStyle.Render(paddedName)
 	}
 
 	size := fmt.Sprintf("%*s", opts.sizeWidth, utils.FormatSize(item.Size))
 	age := fmt.Sprintf("%*s", opts.ageWidth, utils.FormatAge(item.ModifiedAt))
 	if opts.isLocked || opts.isExcluded {
-		size = styles.MutedStyle.Render(size)
-		age = styles.MutedStyle.Render(age)
+		size = m.styles.MutedStyle.Render(size)
+		age = m.styles.MutedStyle.Render(age)
 	} else {
-		size = styles.SizeStyle.Render(size)
-		age = styles.MutedStyle.Render(age)
+		size = m.styles.SizeStyle.Render(size)
+		age = m.styles.MutedStyle.Render(age)
 	}
 
 	return fmt.Sprintf("%s%s%s %s %s %s\n", cursor, checkbox, icon, paddedName, size, age)
@@ -390,14 +389,14 @@ func (m *Model) renderPreviewItemLine(catID string, item types.CleanableItem, is
 
 	cursor := "  "
 	if isCurrent {
-		cursor = styles.CursorStyle.Render("▸ ")
+		cursor = m.styles.CursorStyle.Render("▸ ")
 	}
 
-	checkbox := styles.SuccessStyle.Render("[x]")
+	checkbox := m.styles.SuccessStyle.Render("[x]")
 	if isLocked {
-		checkbox = styles.MutedStyle.Render(" - ")
+		checkbox = m.styles.MutedStyle.Render(" - ")
 	} else if isExcluded {
-		checkbox = styles.MutedStyle.Render("[ ]")
+		checkbox = m.styles.MutedStyle.Render("[ ]")
 	}
 
 	icon := " "
@@ -406,7 +405,7 @@ func (m *Model) renderPreviewItemLine(catID string, item types.CleanableItem, is
 	}
 	icon = padToWidth(icon, previewIconWidth)
 	if isLocked {
-		icon = styles.MutedStyle.Render(icon)
+		icon = m.styles.MutedStyle.Render(icon)
 	}
 
 	displayPath := item.Path
@@ -423,19 +422,19 @@ func (m *Model) renderPreviewItemLine(catID string, item types.CleanableItem, is
 
 	paddedPath := padToWidth(truncated, pathWidth)
 	if isLocked || isExcluded {
-		paddedPath = styles.MutedStyle.Render(paddedPath)
+		paddedPath = m.styles.MutedStyle.Render(paddedPath)
 	} else if isCurrent {
-		paddedPath = styles.SelectedStyle.Render(paddedPath)
+		paddedPath = m.styles.SelectedStyle.Render(paddedPath)
 	}
 
 	size := fmt.Sprintf("%*s", sizeWidth, utils.FormatSize(item.Size))
 	age := fmt.Sprintf("%*s", ageWidth, utils.FormatAge(item.ModifiedAt))
 	if isLocked || isExcluded {
-		size = styles.MutedStyle.Render(size)
-		age = styles.MutedStyle.Render(age)
+		size = m.styles.MutedStyle.Render(size)
+		age = m.styles.MutedStyle.Render(age)
 	} else {
-		size = styles.SizeStyle.Render(size)
-		age = styles.MutedStyle.Render(age)
+		size = m.styles.SizeStyle.Render(size)
+		age = m.styles.MutedStyle.Render(age)
 	}
 
 	return fmt.Sprintf("%s%s %s %s %s %s", cursor, checkbox, icon, paddedPath, size, age)
@@ -475,7 +474,7 @@ func (m *Model) viewPreview() string {
 		addLine("Search: "+m.filterInput.View(), false)
 	}
 	if filterQuery != "" {
-		addLine(styles.MutedStyle.Render(fmt.Sprintf("Filter: \"%s\"", filterQuery)), false)
+		addLine(m.styles.MutedStyle.Render(fmt.Sprintf("Filter: \"%s\"", filterQuery)), false)
 	}
 	addLine(m.renderSectionColumnsHeader(), false)
 
@@ -502,7 +501,7 @@ func (m *Model) viewPreview() string {
 		}
 
 		if len(items) == 0 {
-			addLine(styles.MutedStyle.Render("    (no items)"), false)
+			addLine(m.styles.MutedStyle.Render("    (no items)"), false)
 			continue
 		}
 
@@ -530,7 +529,7 @@ func (m *Model) viewPreview() string {
 		b.WriteString("\n")
 	}
 	if len(bodyLines) > visible {
-		b.WriteString(styles.MutedStyle.Render(fmt.Sprintf("  … [%d-%d / %d]\n", start+1, end, len(bodyLines))))
+		b.WriteString(m.styles.MutedStyle.Render(fmt.Sprintf("  … [%d-%d / %d]\n", start+1, end, len(bodyLines))))
 	}
 	m.updatePreviewStatusMessage()
 	b.WriteString(footer)
@@ -540,12 +539,12 @@ func (m *Model) viewPreview() string {
 func (m *Model) drillDownHeader(path string) string {
 	var b strings.Builder
 
-	b.WriteString(styles.HeaderStyle.Render("Directory Browser"))
+	b.WriteString(m.styles.HeaderStyle.Render("Directory Browser"))
 	b.WriteString("\n\n")
 
-	b.WriteString(styles.MutedStyle.Render("Path: ") + shortenPath(path, m.width-10))
+	b.WriteString(m.styles.MutedStyle.Render("Path: ") + shortenPath(path, m.width-10))
 	b.WriteString("\n")
-	b.WriteString(styles.Divider(60) + "\n")
+	b.WriteString(m.styles.Divider(60) + "\n")
 
 	return b.String()
 }
@@ -555,7 +554,7 @@ func (m *Model) drillDownFooter() string {
 
 	// Status message (e.g., error messages)
 	if m.statusMessage != "" {
-		b.WriteString("\n" + styles.WarningStyle.Render(m.statusMessage))
+		b.WriteString("\n" + m.styles.WarningStyle.Render(m.statusMessage))
 	}
 
 	b.WriteString("\n\n")
@@ -578,7 +577,7 @@ func (m *Model) viewDrillDown() string {
 	b.WriteString(header)
 
 	if len(state.items) == 0 {
-		b.WriteString(styles.MutedStyle.Render("(empty)") + "\n")
+		b.WriteString(m.styles.MutedStyle.Render("(empty)") + "\n")
 	} else {
 		// Sort items based on current sort order
 		sortedItems := m.sortItems(state.items)
@@ -609,7 +608,7 @@ func (m *Model) viewDrillDown() string {
 		}
 
 		if len(sortedItems) > visible {
-			b.WriteString(styles.MutedStyle.Render(fmt.Sprintf("\n  [%d/%d]", state.cursor+1, len(sortedItems))))
+			b.WriteString(m.styles.MutedStyle.Render(fmt.Sprintf("\n  [%d/%d]", state.cursor+1, len(sortedItems))))
 		}
 	}
 

--- a/internal/tui/view_preview.go
+++ b/internal/tui/view_preview.go
@@ -363,11 +363,8 @@ func (m *Model) renderItemRow(opts itemRowOpts) string {
 	}
 	paddedName = padToWidth(paddedName, opts.pathWidth)
 
-	switch {
-	case opts.isLocked || opts.isExcluded:
+	if opts.isLocked || opts.isExcluded {
 		paddedName = m.styles.MutedStyle.Render(paddedName)
-	case opts.isCurrent:
-		paddedName = m.styles.SelectedStyle.Render(paddedName)
 	}
 
 	size := fmt.Sprintf("%*s", opts.sizeWidth, utils.FormatSize(item.Size))
@@ -423,8 +420,6 @@ func (m *Model) renderPreviewItemLine(catID string, item types.CleanableItem, is
 	paddedPath := padToWidth(truncated, pathWidth)
 	if isLocked || isExcluded {
 		paddedPath = m.styles.MutedStyle.Render(paddedPath)
-	} else if isCurrent {
-		paddedPath = m.styles.SelectedStyle.Render(paddedPath)
 	}
 
 	size := fmt.Sprintf("%*s", sizeWidth, utils.FormatSize(item.Size))

--- a/internal/tui/view_report.go
+++ b/internal/tui/view_report.go
@@ -5,25 +5,24 @@ import (
 	"strings"
 	"time"
 
-	"github.com/2ykwang/mac-cleanup-go/internal/styles"
 	"github.com/2ykwang/mac-cleanup-go/internal/utils"
 )
 
 func (m *Model) reportHeader() string {
 	var b strings.Builder
 
-	b.WriteString(styles.HeaderStyle.Render("Cleanup Complete"))
+	b.WriteString(m.styles.HeaderStyle.Render("Cleanup Complete"))
 	b.WriteString("\n\n")
 
 	// Summary
-	b.WriteString(fmt.Sprintf("Freed:     %s\n", styles.SizeStyle.Render(formatSize(m.report.FreedSpace))))
-	b.WriteString(fmt.Sprintf("Succeeded: %s\n", styles.SuccessStyle.Render(fmt.Sprintf("%d", m.report.CleanedItems))))
+	b.WriteString(fmt.Sprintf("Freed:     %s\n", m.styles.SizeStyle.Render(formatSize(m.report.FreedSpace))))
+	b.WriteString(fmt.Sprintf("Succeeded: %s\n", m.styles.SuccessStyle.Render(fmt.Sprintf("%d", m.report.CleanedItems))))
 	if m.report.FailedItems > 0 {
-		b.WriteString(fmt.Sprintf("Failed:    %s\n", styles.DangerStyle.Render(fmt.Sprintf("%d", m.report.FailedItems))))
+		b.WriteString(fmt.Sprintf("Failed:    %s\n", m.styles.DangerStyle.Render(fmt.Sprintf("%d", m.report.FailedItems))))
 	}
 	b.WriteString(fmt.Sprintf("Time:      %s\n\n", m.report.Duration.Round(time.Millisecond)))
 
-	b.WriteString(styles.Divider(m.reportDividerWidth()) + "\n")
+	b.WriteString(m.styles.Divider(m.reportDividerWidth()) + "\n")
 
 	return b.String()
 }
@@ -57,7 +56,7 @@ func (m *Model) viewReport() string {
 
 	// Show scroll indicator at top if scrolled
 	if m.reportScroll > 0 {
-		b.WriteString(styles.MutedStyle.Render(fmt.Sprintf("  ↑ %d more lines above\n", m.reportScroll)))
+		b.WriteString(m.styles.MutedStyle.Render(fmt.Sprintf("  ↑ %d more lines above\n", m.reportScroll)))
 	} else {
 		b.WriteString("\n")
 	}
@@ -71,7 +70,7 @@ func (m *Model) viewReport() string {
 	// Show scroll indicator at bottom if more content
 	remaining := totalLines - end
 	if remaining > 0 {
-		b.WriteString(styles.MutedStyle.Render(fmt.Sprintf("  ↓ %d more lines below\n", remaining)))
+		b.WriteString(m.styles.MutedStyle.Render(fmt.Sprintf("  ↓ %d more lines below\n", remaining)))
 	} else {
 		b.WriteString("\n")
 	}
@@ -89,12 +88,12 @@ func (m *Model) buildReportLines() []string {
 	for _, result := range m.report.Results {
 		if len(result.Errors) == 0 && result.CleanedItems > 0 {
 			if !hasSuccess {
-				lines = append(lines, styles.SuccessStyle.Render("Succeeded:"))
+				lines = append(lines, m.styles.SuccessStyle.Render("Succeeded:"))
 				hasSuccess = true
 			}
 			size := fmt.Sprintf("%*s", sizeWidth, utils.FormatSize(result.FreedSpace))
 			name := padToWidth(truncateToWidth(result.Category.Name, nameWidth, false), nameWidth)
-			lines = append(lines, fmt.Sprintf("  %s %s %s", styles.SuccessStyle.Render("✓"), name, styles.SizeStyle.Render(size)))
+			lines = append(lines, fmt.Sprintf("  %s %s %s", m.styles.SuccessStyle.Render("✓"), name, m.styles.SizeStyle.Render(size)))
 		}
 	}
 
@@ -102,15 +101,15 @@ func (m *Model) buildReportLines() []string {
 	for _, result := range m.report.Results {
 		if len(result.Errors) > 0 && result.CleanedItems > 0 {
 			if !hasSuccess {
-				lines = append(lines, styles.SuccessStyle.Render("Succeeded:"))
+				lines = append(lines, m.styles.SuccessStyle.Render("Succeeded:"))
 				hasSuccess = true
 			}
 			size := fmt.Sprintf("%*s", sizeWidth, utils.FormatSize(result.FreedSpace))
 			name := padToWidth(truncateToWidth(result.Category.Name, nameWidth, false), nameWidth)
 			lines = append(lines, fmt.Sprintf("  %s %s %s",
-				styles.WarningStyle.Render("△"),
+				m.styles.WarningStyle.Render("△"),
 				name,
-				styles.SizeStyle.Render(size)))
+				m.styles.SizeStyle.Render(size)))
 		}
 	}
 
@@ -122,22 +121,22 @@ func (m *Model) buildReportLines() []string {
 				if hasSuccess {
 					lines = append(lines, "") // blank line
 				}
-				lines = append(lines, styles.DangerStyle.Render("Failed:"))
+				lines = append(lines, m.styles.DangerStyle.Render("Failed:"))
 				hasFailed = true
 			}
 
 			// Show category with error count
 			if result.CleanedItems > 0 {
 				lines = append(lines, fmt.Sprintf("  %s %s: %s succeeded, %s failed",
-					styles.WarningStyle.Render("⚠"),
+					m.styles.WarningStyle.Render("⚠"),
 					result.Category.Name,
-					styles.SuccessStyle.Render(fmt.Sprintf("%d", result.CleanedItems)),
-					styles.DangerStyle.Render(fmt.Sprintf("%d", len(result.Errors)))))
+					m.styles.SuccessStyle.Render(fmt.Sprintf("%d", result.CleanedItems)),
+					m.styles.DangerStyle.Render(fmt.Sprintf("%d", len(result.Errors)))))
 			} else {
 				lines = append(lines, fmt.Sprintf("  %s %s: %s failed",
-					styles.DangerStyle.Render("✗"),
+					m.styles.DangerStyle.Render("✗"),
 					result.Category.Name,
-					styles.DangerStyle.Render(fmt.Sprintf("%d", len(result.Errors)))))
+					m.styles.DangerStyle.Render(fmt.Sprintf("%d", len(result.Errors)))))
 			}
 
 			// Show individual errors (truncate long paths)
@@ -146,7 +145,7 @@ func (m *Model) buildReportLines() []string {
 				if len(displayErr) > 60 {
 					displayErr = "..." + displayErr[len(displayErr)-57:]
 				}
-				lines = append(lines, styles.MutedStyle.Render(fmt.Sprintf("    └ %s", displayErr)))
+				lines = append(lines, m.styles.MutedStyle.Render(fmt.Sprintf("    └ %s", displayErr)))
 			}
 		}
 	}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -60,9 +60,9 @@ func FormatSize(bytes int64) string {
 	case bytes >= GB:
 		return fmt.Sprintf("%.1f GB", float64(bytes)/GB)
 	case bytes >= MB:
-		return fmt.Sprintf("%.1f MB", float64(bytes)/MB)
+		return fmt.Sprintf("%d MB", (bytes+MB/2)/MB)
 	case bytes >= KB:
-		return fmt.Sprintf("%.1f KB", float64(bytes)/KB)
+		return fmt.Sprintf("%d KB", (bytes+KB/2)/KB)
 	default:
 		return fmt.Sprintf("%d B", bytes)
 	}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -51,13 +51,13 @@ func TestFormatSize_Bytes(t *testing.T) {
 }
 
 func TestFormatSize_KB(t *testing.T) {
-	assert.Equal(t, "1.0 KB", FormatSize(1024))
-	assert.Equal(t, "1.5 KB", FormatSize(1536))
+	assert.Equal(t, "1 KB", FormatSize(1024))
+	assert.Equal(t, "2 KB", FormatSize(1536))
 }
 
 func TestFormatSize_MB(t *testing.T) {
-	assert.Equal(t, "1.0 MB", FormatSize(1048576))
-	assert.Equal(t, "1.5 MB", FormatSize(1572864))
+	assert.Equal(t, "1 MB", FormatSize(1048576))
+	assert.Equal(t, "2 MB", FormatSize(1572864))
 }
 
 func TestFormatSize_GB(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -7,10 +7,12 @@ import (
 	"os"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 
 	"github.com/2ykwang/mac-cleanup-go/internal/cli"
 	"github.com/2ykwang/mac-cleanup-go/internal/config"
 	"github.com/2ykwang/mac-cleanup-go/internal/logger"
+	"github.com/2ykwang/mac-cleanup-go/internal/styles"
 	"github.com/2ykwang/mac-cleanup-go/internal/tui"
 	"github.com/2ykwang/mac-cleanup-go/internal/userconfig"
 	pkgversion "github.com/2ykwang/mac-cleanup-go/internal/version"
@@ -80,6 +82,9 @@ func main() {
 	}
 
 	if *doClean {
+		// CLI path has no event loop, so detect background once up front.
+		theme := styles.New(lipgloss.HasDarkBackground(os.Stdin, os.Stdout))
+
 		userCfg, err := userconfig.Load()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to load user config: %v\n", err)
@@ -112,7 +117,7 @@ func main() {
 			}
 		}
 
-		fmt.Print(cli.FormatReport(report, *dryRun))
+		fmt.Print(cli.FormatReport(report, *dryRun, theme))
 		return
 	}
 


### PR DESCRIPTION
## What changed
- Colors now adapt to the terminal's background (light vs dark) instead of using a fixed palette.
- Pressing `enter` with nothing selected opens a hint dialog instead of doing nothing.

## Why
- The fixed palette was unreadable on light terminals (white text on white background) and on saturated dark backgrounds (like
 the Ocean theme).
- New users hit `enter` first and got no feedback, the path from "scan complete" to "clean" was undiscoverable.

## How to test (optional)
- `make run` on a dark terminal — borders/text legible
- `make run` on a light terminal — borders/text legible, no white-on-white
- Theme change mid-run requires restart (one-time detection at startup)
- On the list view with nothing selected, press `enter` → hint dialog appears, `esc` dismisses