### PR TITLE
Expand cleanup categories and skip targets while blocking processes run

### DIFF
--- a/internal/cleaner/service.go
+++ b/internal/cleaner/service.go
@@ -139,6 +139,12 @@ func buildJob(
 	if r.Category.Method == types.MethodManual {
 		return CleanJob{}, false
 	}
+	for _, proc := range r.Category.BlockedByProcesses {
+		if utils.IsProcessRunning(proc) {
+			logger.Warn("skipping target: blocking process running", "id", id, "process", proc)
+			return CleanJob{}, false
+		}
+	}
 
 	excludedMap := excluded[id]
 	var items []types.CleanableItem

--- a/internal/cleaner/service_test.go
+++ b/internal/cleaner/service_test.go
@@ -124,6 +124,33 @@ func TestPrepareJobs_SkipsManualMethod(t *testing.T) {
 	}
 }
 
+func TestPrepareJobs_SkipsCategory_WhenBlockingProcessRunning(t *testing.T) {
+	original := utils.IsProcessRunning
+	defer func() { utils.IsProcessRunning = original }()
+	utils.IsProcessRunning = func(name string) bool { return name == "Xcode" }
+
+	service := NewCleanService(target.NewRegistry())
+
+	blocked := types.NewScanResult(types.Category{
+		ID:                 "xcode-derived",
+		Name:               "Xcode DerivedData",
+		Method:             types.MethodTrash,
+		BlockedByProcesses: []string{"Xcode"},
+	})
+	blocked.Items = newTestItems("/path1")
+
+	resultMap := map[string]*types.ScanResult{
+		"xcode-derived": blocked,
+		"cat2":          newTestScanResult("cat2", "Category 2", types.MethodTrash, newTestItems("/path2")),
+	}
+	selected := map[string]bool{"xcode-derived": true, "cat2": true}
+
+	jobs := service.PrepareJobs(resultMap, selected, nil)
+
+	assert.Len(t, jobs, 1)
+	assert.Equal(t, "cat2", jobs[0].Category.ID)
+}
+
 func TestPrepareJobs_FiltersExcludedItems(t *testing.T) {
 	service := NewCleanService(target.NewRegistry())
 

--- a/internal/config/targets.yaml
+++ b/internal/config/targets.yaml
@@ -82,6 +82,40 @@ categories:
     paths:
       - "~/Library/DiagnosticReports/*"
 
+  - id: shell-residue
+    name: Shell History Residue
+    group: system
+    safety: safe
+    method: permanent
+    note: Backup history files and stale shell metadata - regenerated on next shell start
+    paths:
+      - "~/.bash_history.bak*"
+      - "~/.zsh_history.bak*"
+      - "~/.config/fish/fish_history.bak*"
+      - "~/.zcompdump*"
+      - "~/.lesshst"
+      - "~/.viminfo.tmp"
+      - "~/.wget-hsts"
+
+  - id: identity-caches
+    name: Identity Caches
+    group: system
+    safety: safe
+    method: trash
+    note: Apple identity service caches - regenerated automatically
+    paths:
+      - "~/Library/IdentityCaches/*"
+
+  - id: macos-installer
+    name: macOS Installer Files
+    group: storage
+    safety: moderate
+    method: trash
+    note: Old macOS installer leftovers - re-download from App Store if needed
+    paths:
+      - "/Applications/Install macOS*.app"
+      - "/macOS Install Data"
+
   # ===== Browsers =====
   - id: browser-chrome
     name: Chrome Cache
@@ -193,6 +227,8 @@ categories:
     paths:
       - "~/Library/Developer/Xcode/DerivedData/*"
       - "~/Library/Developer/Xcode/iOS Device Logs/*"
+    blocked_by_processes:
+      - Xcode
 
   - id: xcode-archives
     name: Xcode Archives
@@ -212,6 +248,9 @@ categories:
     paths:
       - "~/Library/Developer/CoreSimulator/Caches/*"
       - "~/Library/Logs/CoreSimulator/*"
+    blocked_by_processes:
+      - Simulator
+      - Xcode
 
   - id: android
     name: Android SDK Cache
@@ -306,6 +345,7 @@ categories:
     note: Gradle build cache - increases build time after deletion
     paths:
       - "~/.gradle/caches/*"
+      - "~/.gradle/daemon/*"
 
   - id: maven
     name: Maven Cache
@@ -619,6 +659,166 @@ categories:
       - "~/Library/Developer/Xcode/iOS Device Logs/*"
       - "~/Library/Developer/Xcode/watchOS Device Logs/*"
 
+  - id: pre-commit
+    name: pre-commit Cache
+    group: dev
+    safety: safe
+    method: trash
+    note: pre-commit framework hook cache - rebuilt on next run
+    paths:
+      - "~/.cache/pre-commit/*"
+
+  - id: prisma
+    name: Prisma Cache
+    group: dev
+    safety: safe
+    method: trash
+    note: Prisma ORM engine cache
+    paths:
+      - "~/.cache/prisma/*"
+
+  - id: puppeteer
+    name: Puppeteer Browser Cache
+    group: dev
+    safety: moderate
+    method: trash
+    note: Puppeteer downloaded Chromium - re-downloaded on next run
+    paths:
+      - "~/.cache/puppeteer/*"
+
+  - id: zig
+    name: Zig Cache
+    group: dev
+    safety: safe
+    method: trash
+    note: Zig compiler local cache
+    paths:
+      - "~/.cache/zig/*"
+
+  - id: opam
+    name: OPAM Download Cache
+    group: dev
+    safety: safe
+    method: trash
+    note: OCaml OPAM package download cache
+    paths:
+      - "~/.cache/opam/*"
+      - "~/.opam/download-cache/*"
+
+  - id: gitlab-runner
+    name: GitLab Runner Cache
+    group: dev
+    safety: safe
+    method: trash
+    note: GitLab Runner local cache
+    paths:
+      - "~/.cache/gitlab-runner/*"
+
+  - id: circleci
+    name: CircleCI Cache
+    group: dev
+    safety: safe
+    method: trash
+    note: CircleCI local cache
+    paths:
+      - "~/.circleci/cache/*"
+
+  - id: jenkins
+    name: Jenkins Workspace Build Cache
+    group: dev
+    safety: moderate
+    method: trash
+    note: Jenkins workspace build artifacts - regenerated on next build
+    paths:
+      - "~/.jenkins/workspace/*/target/*"
+
+  - id: sonar
+    name: SonarQube Cache
+    group: dev
+    safety: safe
+    method: trash
+    note: SonarQube scanner local cache
+    paths:
+      - "~/.sonar/*"
+
+  - id: expo
+    name: Expo Cache
+    group: dev
+    safety: moderate
+    method: trash
+    note: Expo React Native dev caches - re-downloaded on next run
+    paths:
+      - "~/.expo/expo-go/*"
+      - "~/.expo/android-apk-cache/*"
+      - "~/.expo/ios-simulator-app-cache/*"
+      - "~/.expo/native-modules-cache/*"
+      - "~/.expo/schema-cache/*"
+      - "~/.expo/template-cache/*"
+      - "~/.expo/versions-cache/*"
+
+  - id: ruby-bundle
+    name: Ruby Bundler Cache
+    group: dev
+    safety: safe
+    method: trash
+    note: Ruby Bundler download cache
+    paths:
+      - "~/.bundle/cache/*"
+
+  - id: vscode-ripgrep
+    name: VS Code ripgrep Cache
+    group: dev
+    safety: safe
+    method: trash
+    note: VS Code ripgrep download cache
+    paths:
+      - "~/.cache/vscode-ripgrep/*"
+
+  - id: opencode
+    name: OpenCode Cache
+    group: dev
+    safety: safe
+    method: trash
+    note: OpenCode CLI cache
+    paths:
+      - "~/.cache/opencode/*"
+
+  - id: kaku
+    name: Kaku Cache
+    group: dev
+    safety: safe
+    method: trash
+    note: Kaku tool cache
+    paths:
+      - "~/.cache/kaku/*"
+
+  - id: curl-cache
+    name: curl Cache
+    group: system
+    safety: safe
+    method: trash
+    note: curl HTTP client cache
+    paths:
+      - "~/.cache/curl/*"
+
+  - id: wget-cache
+    name: wget Cache
+    group: system
+    safety: safe
+    method: trash
+    note: wget HTTP client cache
+    paths:
+      - "~/.cache/wget/*"
+
+  - id: oh-my-zsh
+    name: Oh My Zsh Cache
+    group: system
+    safety: safe
+    method: trash
+    note: Oh My Zsh framework cache
+    paths:
+      - "~/.oh-my-zsh/cache/*"
+
   # ===== Applications =====
   - id: steam
     name: Steam Cache
@@ -866,6 +1066,160 @@ categories:
     note: ChatGPT desktop app cache
     paths:
       - "~/Library/Caches/com.openai.chat/*"
+
+  - id: codex
+    name: Codex Cache
+    group: app
+    safety: safe
+    method: trash
+    note: OpenAI Codex desktop app and CLI cache
+    paths:
+      - "~/Library/Application Support/Codex/Cache/*"
+      - "~/Library/Application Support/Codex/Code Cache/*"
+      - "~/Library/Application Support/Codex/GPUCache/*"
+      - "~/Library/Application Support/Codex/DawnGraphiteCache/*"
+      - "~/Library/Application Support/Codex/DawnWebGPUCache/*"
+      - "~/Library/Logs/com.openai.codex/*"
+
+  - id: antigravity
+    name: Antigravity Cache
+    group: app
+    safety: safe
+    method: trash
+    note: Antigravity browser cache
+    paths:
+      - "~/Library/Application Support/Antigravity/Cache/*"
+      - "~/Library/Application Support/Antigravity/Code Cache/*"
+      - "~/Library/Application Support/Antigravity/GPUCache/*"
+      - "~/Library/Application Support/Antigravity/DawnGraphiteCache/*"
+      - "~/Library/Application Support/Antigravity/DawnWebGPUCache/*"
+
+  - id: qoder
+    name: Qoder Cache
+    group: app
+    safety: safe
+    method: trash
+    note: Qoder IDE (VS Code fork) cache
+    paths:
+      - "~/Library/Application Support/Qoder/Cache/*"
+      - "~/Library/Application Support/Qoder/CachedData/*"
+      - "~/Library/Application Support/Qoder/CachedExtensionVSIXs/*"
+      - "~/Library/Application Support/Qoder/Code Cache/*"
+      - "~/Library/Application Support/Qoder/GPUCache/*"
+      - "~/Library/Application Support/Qoder/DawnGraphiteCache/*"
+      - "~/Library/Application Support/Qoder/DawnWebGPUCache/*"
+      - "~/Library/Application Support/Qoder/logs/*"
+
+  - id: filo
+    name: Filo Cache
+    group: app
+    safety: safe
+    method: trash
+    note: Filo Electron app cache
+    paths:
+      - "~/Library/Application Support/Filo/production/Cache/*"
+      - "~/Library/Application Support/Filo/production/Code Cache/*"
+      - "~/Library/Application Support/Filo/production/GPUCache/*"
+      - "~/Library/Application Support/Filo/production/DawnGraphiteCache/*"
+      - "~/Library/Application Support/Filo/production/DawnWebGPUCache/*"
+
+  - id: stremio
+    name: Stremio Cache
+    group: app
+    safety: safe
+    method: trash
+    note: Stremio media streaming cache
+    paths:
+      - "~/Library/Caches/smart.stremio*/*"
+      - "~/Library/Application Support/stremio/stremio-server/stremio-cache/*"
+
+  - id: pcsx2
+    name: PCSX2 Cache
+    group: app
+    safety: safe
+    method: trash
+    note: PCSX2 PS2 emulator cache and shader cache
+    paths:
+      - "~/Library/Caches/net.pcsx2.PCSX2/*"
+      - "~/Library/Application Support/PCSX2/cache/*"
+      - "~/Library/Logs/PCSX2/*"
+
+  - id: rpcs3
+    name: RPCS3 Cache
+    group: app
+    safety: safe
+    method: trash
+    note: RPCS3 PS3 emulator cache and logs
+    paths:
+      - "~/Library/Caches/net.rpcs3.rpcs3/*"
+      - "~/Library/Application Support/rpcs3/logs/*"
+
+  - id: google-updater
+    name: Google Updater Cache
+    group: app
+    safety: safe
+    method: trash
+    note: Google software updater downloaded packages
+    paths:
+      - "~/Library/Application Support/Google/GoogleUpdater/crx_cache/*"
+      - "~/Library/Application Support/Google/GoogleUpdater/*.old"
+
+  - id: davinci-cacheclip
+    name: DaVinci Resolve CacheClip
+    group: app
+    safety: moderate
+    method: trash
+    note: DaVinci Resolve render/proxy cache - regenerated on next render
+    paths:
+      - "~/Movies/CacheClip/*"
+
+  - id: virtualbox
+    name: VirtualBox Cache
+    group: app
+    safety: safe
+    method: trash
+    note: VirtualBox runtime cache
+    paths:
+      - "~/VirtualBox VMs/.cache"
+
+  - id: zed-logs
+    name: Zed Logs
+    group: app
+    safety: safe
+    method: trash
+    note: Zed editor logs
+    paths:
+      - "~/Library/Logs/Zed/*"
+
+  - id: claude-logs
+    name: Claude Logs
+    group: app
+    safety: safe
+    method: trash
+    note: Claude desktop app logs
+    paths:
+      - "~/Library/Logs/Claude/*"
+
+  - id: messages-cache
+    name: Messages Preview Cache
+    group: app
+    safety: safe
+    method: trash
+    note: Messages app preview attachments and stickers cache
+    paths:
+      - "~/Library/Messages/Caches/Previews/Attachments/*"
+      - "~/Library/Messages/Caches/Previews/StickerCache/*"
+
+  - id: wallpaper-cache
+    name: Wallpaper Cache
+    group: system
+    safety: safe
+    method: trash
+    note: macOS dynamic wallpaper agent cache and aerial thumbnails
+    paths:
+      - "~/Library/Containers/com.apple.wallpaper.agent/Data/Library/Caches/*"
+      - "~/Library/Containers/com.apple.wallpaper.extension.aerials/Data/tmp/*"
+      - "~/Library/Application Support/com.apple.wallpaper/aerials/thumbnails/*"
 
   - id: electron-updaters
     name: App Updaters (ShipIt)

--- a/internal/target/path.go
+++ b/internal/target/path.go
@@ -23,6 +23,12 @@ func (s *PathTarget) Category() types.Category {
 }
 
 func (s *PathTarget) IsAvailable() bool {
+	for _, proc := range s.category.BlockedByProcesses {
+		if utils.IsProcessRunning(proc) {
+			return false
+		}
+	}
+
 	// For command-based methods, check if command exists
 	if s.category.CheckCmd != "" {
 		return utils.CommandExists(s.category.CheckCmd)

--- a/internal/target/path_test.go
+++ b/internal/target/path_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/2ykwang/mac-cleanup-go/internal/types"
+	"github.com/2ykwang/mac-cleanup-go/internal/utils"
 )
 
 // --- Category Tests ---
@@ -89,6 +90,38 @@ func TestIsAvailable_ReturnsTrue_WhenPathsHaveMatchingFiles(t *testing.T) {
 	cat := types.Category{
 		ID:    "test",
 		Paths: []string{filepath.Join(tmpDir, "*")},
+	}
+
+	s := NewPathTarget(cat)
+
+	assert.True(t, s.IsAvailable())
+}
+
+func TestIsAvailable_ReturnsFalse_WhenBlockedProcessRunning(t *testing.T) {
+	original := utils.IsProcessRunning
+	defer func() { utils.IsProcessRunning = original }()
+	utils.IsProcessRunning = func(name string) bool { return name == "Xcode" }
+
+	cat := types.Category{
+		ID:                 "test",
+		CheckCmd:           "ls",
+		BlockedByProcesses: []string{"Xcode"},
+	}
+
+	s := NewPathTarget(cat)
+
+	assert.False(t, s.IsAvailable())
+}
+
+func TestIsAvailable_ReturnsTrue_WhenBlockedProcessNotRunning(t *testing.T) {
+	original := utils.IsProcessRunning
+	defer func() { utils.IsProcessRunning = original }()
+	utils.IsProcessRunning = func(name string) bool { return false }
+
+	cat := types.Category{
+		ID:                 "test",
+		CheckCmd:           "ls",
+		BlockedByProcesses: []string{"Xcode"},
 	}
 
 	s := NewPathTarget(cat)

--- a/internal/target/path_test.go
+++ b/internal/target/path_test.go
@@ -116,7 +116,7 @@ func TestIsAvailable_ReturnsFalse_WhenBlockedProcessRunning(t *testing.T) {
 func TestIsAvailable_ReturnsTrue_WhenBlockedProcessNotRunning(t *testing.T) {
 	original := utils.IsProcessRunning
 	defer func() { utils.IsProcessRunning = original }()
-	utils.IsProcessRunning = func(name string) bool { return false }
+	utils.IsProcessRunning = func(_ string) bool { return false }
 
 	cat := types.Category{
 		ID:                 "test",

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -64,6 +64,9 @@ type Category struct {
 	Guide    string        `yaml:"guide,omitempty"`
 	Paths    []string      `yaml:"paths,omitempty"`
 	CheckCmd string        `yaml:"check_cmd,omitempty"`
+
+	// BlockedByProcesses lists process names that, when running, make this target unavailable.
+	BlockedByProcesses []string `yaml:"blocked_by_processes,omitempty"`
 }
 
 type Group struct {

--- a/internal/utils/process.go
+++ b/internal/utils/process.go
@@ -1,0 +1,16 @@
+package utils
+
+import "strings"
+
+// IsProcessRunning reports whether a process with the given name is currently running.
+// Uses `pgrep -x` for an exact name match. Returns false if pgrep is missing or errors.
+var IsProcessRunning = func(name string) bool {
+	if name == "" {
+		return false
+	}
+	out, err := execCommand("pgrep", "-x", name).Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) != ""
+}

--- a/internal/utils/process_test.go
+++ b/internal/utils/process_test.go
@@ -10,7 +10,7 @@ import (
 func TestIsProcessRunning_ReturnsTrue_WhenPgrepFindsProcess(t *testing.T) {
 	original := execCommand
 	defer func() { execCommand = original }()
-	execCommand = func(name string, args ...string) *exec.Cmd {
+	execCommand = func(_ string, _ ...string) *exec.Cmd {
 		return exec.Command("printf", "12345\n")
 	}
 
@@ -20,7 +20,7 @@ func TestIsProcessRunning_ReturnsTrue_WhenPgrepFindsProcess(t *testing.T) {
 func TestIsProcessRunning_ReturnsFalse_WhenPgrepEmpty(t *testing.T) {
 	original := execCommand
 	defer func() { execCommand = original }()
-	execCommand = func(name string, args ...string) *exec.Cmd {
+	execCommand = func(_ string, _ ...string) *exec.Cmd {
 		return exec.Command("true")
 	}
 
@@ -30,7 +30,7 @@ func TestIsProcessRunning_ReturnsFalse_WhenPgrepEmpty(t *testing.T) {
 func TestIsProcessRunning_ReturnsFalse_WhenPgrepErrors(t *testing.T) {
 	original := execCommand
 	defer func() { execCommand = original }()
-	execCommand = func(name string, args ...string) *exec.Cmd {
+	execCommand = func(_ string, _ ...string) *exec.Cmd {
 		return exec.Command("false")
 	}
 

--- a/internal/utils/process_test.go
+++ b/internal/utils/process_test.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsProcessRunning_ReturnsTrue_WhenPgrepFindsProcess(t *testing.T) {
+	original := execCommand
+	defer func() { execCommand = original }()
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("printf", "12345\n")
+	}
+
+	assert.True(t, IsProcessRunning("Xcode"))
+}
+
+func TestIsProcessRunning_ReturnsFalse_WhenPgrepEmpty(t *testing.T) {
+	original := execCommand
+	defer func() { execCommand = original }()
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("true")
+	}
+
+	assert.False(t, IsProcessRunning("Xcode"))
+}
+
+func TestIsProcessRunning_ReturnsFalse_WhenPgrepErrors(t *testing.T) {
+	original := execCommand
+	defer func() { execCommand = original }()
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("false")
+	}
+
+	assert.False(t, IsProcessRunning("Xcode"))
+}
+
+func TestIsProcessRunning_ReturnsFalse_WhenNameEmpty(t *testing.T) {
+	assert.False(t, IsProcessRunning(""))
+}


### PR DESCRIPTION
## What changed
- Skip Xcode DerivedData / iOS Simulator targets when those apps are running
- Added 31 new cleanup categories 

## Why
- Cleaning caches while the app is running can corrupt the active build session

## How to test (optional)