### PR TITLE
Add timeout to Docker availability check and warn when unreachable

### DIFF
--- a/internal/target/deps.go
+++ b/internal/target/deps.go
@@ -3,4 +3,7 @@ package target
 import "os/exec"
 
 // Function variables for testing
-var execCommand = exec.Command
+var (
+	execCommand        = exec.Command
+	execCommandContext = exec.CommandContext
+)

--- a/internal/target/docker.go
+++ b/internal/target/docker.go
@@ -1,12 +1,14 @@
 package target
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/2ykwang/mac-cleanup-go/internal/logger"
 	"github.com/2ykwang/mac-cleanup-go/internal/types"
@@ -34,14 +36,20 @@ func (s *DockerTarget) Category() types.Category {
 	return s.category
 }
 
+// dockerVersionTimeout bounds the `docker version` probe: it runs synchronously
+// during startup (Registry.Available), so a hung Docker daemon must not block
+// indefinitely. A var so tests can shorten it.
+var dockerVersionTimeout = 3 * time.Second
+
 func (s *DockerTarget) IsAvailable() bool {
 	if !utils.CommandExists("docker") {
 		logger.Debug("docker command not found")
 		return false
 	}
-	cmd := execCommand("docker", "version")
-	if err := cmd.Run(); err != nil {
-		logger.Warn("docker daemon not running", "error", err)
+	ctx, cancel := context.WithTimeout(context.Background(), dockerVersionTimeout)
+	defer cancel()
+	if err := execCommandContext(ctx, "docker", "version").Run(); err != nil {
+		logger.Warn("docker not available", "error", err)
 		return false
 	}
 	return true

--- a/internal/target/docker_test.go
+++ b/internal/target/docker_test.go
@@ -1,10 +1,12 @@
 package target
 
 import (
+	"context"
 	"math"
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -163,12 +165,16 @@ func withDockerExecFixture(t *testing.T, fixture dockerExecFixture) func() {
 	t.Helper()
 
 	originalCommandExists := utils.CommandExists
-	original := execCommand
+	originalCmd := execCommand
+	originalCtx := execCommandContext
 
 	utils.CommandExists = func(_ string) bool {
 		return fixture.commandExists
 	}
-	execCommand = func(_ string, args ...string) *exec.Cmd {
+	// build returns a canned command for the given docker args. IsAvailable now
+	// goes through execCommandContext while Scan/Clean still use execCommand, so
+	// both vars are stubbed with the same logic.
+	build := func(args ...string) *exec.Cmd {
 		if len(args) > 0 && args[0] == "version" {
 			if fixture.versionOK {
 				return exec.Command("true")
@@ -189,10 +195,17 @@ func withDockerExecFixture(t *testing.T, fixture dockerExecFixture) func() {
 		}
 		return exec.Command("true")
 	}
+	execCommand = func(_ string, args ...string) *exec.Cmd {
+		return build(args...)
+	}
+	execCommandContext = func(_ context.Context, _ string, args ...string) *exec.Cmd {
+		return build(args...)
+	}
 
 	return func() {
 		utils.CommandExists = originalCommandExists
-		execCommand = original
+		execCommand = originalCmd
+		execCommandContext = originalCtx
 	}
 }
 
@@ -204,6 +217,32 @@ func stubDockerScan(t *testing.T, verboseOutput, summaryOutput string) func() {
 		verboseOutput: verboseOutput,
 		summaryOutput: summaryOutput,
 	})
+}
+
+func TestIsAvailable_ReturnsFalse_WhenVersionTimesOut(t *testing.T) {
+	originalExists := utils.CommandExists
+	originalCtx := execCommandContext
+	originalTimeout := dockerVersionTimeout
+	defer func() {
+		utils.CommandExists = originalExists
+		execCommandContext = originalCtx
+		dockerVersionTimeout = originalTimeout
+	}()
+
+	utils.CommandExists = func(_ string) bool { return true }
+	dockerVersionTimeout = 50 * time.Millisecond
+	execCommandContext = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "sleep", "5")
+	}
+
+	s := NewDockerTarget(types.Category{ID: "docker"})
+
+	start := time.Now()
+	available := s.IsAvailable()
+	elapsed := time.Since(start)
+
+	assert.False(t, available)
+	assert.Less(t, elapsed, time.Second)
 }
 
 func TestDockerTarget_IsAvailable_ReturnsFalse_WhenDockerNotExists(t *testing.T) {

--- a/internal/tui/state.go
+++ b/internal/tui/state.go
@@ -53,13 +53,14 @@ type layoutState struct {
 }
 
 type scanState struct {
-	scanCompleted  int
-	scanTotal      int
-	scanRegistered int
-	scanning       bool
-	spinner        spinner.Model
-	scanDoneIDs    map[string]bool
-	scanErrors     []scanErrorInfo
+	scanCompleted     int
+	scanTotal         int
+	scanRegistered    int
+	scanning          bool
+	spinner           spinner.Model
+	scanDoneIDs       map[string]bool
+	scanErrors        []scanErrorInfo
+	dockerUnreachable bool // docker installed but its daemon did not respond
 }
 
 type previewState struct {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -12,6 +12,7 @@ import (
 	"github.com/2ykwang/mac-cleanup-go/internal/styles"
 	"github.com/2ykwang/mac-cleanup-go/internal/target"
 	"github.com/2ykwang/mac-cleanup-go/internal/types"
+	"github.com/2ykwang/mac-cleanup-go/internal/utils"
 )
 
 func (m *Model) startScan() tea.Cmd {
@@ -19,6 +20,7 @@ func (m *Model) startScan() tea.Cmd {
 	scanners := m.registry.Available()
 	m.scanTotal = len(scanners)
 	m.scanCompleted = 0
+	m.dockerUnreachable = m.detectDockerUnreachable(scanners)
 	clear(m.scanDoneIDs)
 
 	logger.Info("scan started", "registered", m.scanRegistered, "available", m.scanTotal)
@@ -38,6 +40,21 @@ func (m *Model) startScan() tea.Cmd {
 		}
 	}
 	return tea.Batch(cmds...)
+}
+
+// detectDockerUnreachable reports whether Docker is a configured target and is
+// installed, yet absent from the available scanners — i.e. its daemon did not
+// respond (stopped or hung). Surfaced as a hint; not used for control flow.
+func (m *Model) detectDockerUnreachable(available []target.Target) bool {
+	if _, ok := m.registry.Get("docker"); !ok {
+		return false
+	}
+	for _, s := range available {
+		if s.Category().ID == "docker" {
+			return false
+		}
+	}
+	return utils.CommandExists("docker")
 }
 
 // Update handles messages

--- a/internal/tui/update_test.go
+++ b/internal/tui/update_test.go
@@ -1,0 +1,71 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/2ykwang/mac-cleanup-go/internal/target"
+	"github.com/2ykwang/mac-cleanup-go/internal/types"
+	"github.com/2ykwang/mac-cleanup-go/internal/utils"
+)
+
+func newTestModelWithRegistry(r *target.Registry) *Model {
+	return &Model{configState: configState{registry: r}}
+}
+
+func newTestDockerRegistry() *target.Registry {
+	r := target.NewRegistry()
+	r.Register(target.NewDockerTarget(types.Category{ID: "docker", Name: "Docker"}))
+	return r
+}
+
+func TestDetectDockerUnreachable_True_WhenInstalledButNotAvailable(t *testing.T) {
+	original := utils.CommandExists
+	defer func() { utils.CommandExists = original }()
+	utils.CommandExists = func(_ string) bool { return true }
+
+	m := newTestModelWithRegistry(newTestDockerRegistry())
+	available := []target.Target{target.NewPathTarget(types.Category{ID: "system-cache"})}
+
+	result := m.detectDockerUnreachable(available)
+
+	assert.True(t, result)
+}
+
+func TestDetectDockerUnreachable_False_WhenDockerAvailable(t *testing.T) {
+	original := utils.CommandExists
+	defer func() { utils.CommandExists = original }()
+	utils.CommandExists = func(_ string) bool { return true }
+
+	m := newTestModelWithRegistry(newTestDockerRegistry())
+	available := []target.Target{target.NewDockerTarget(types.Category{ID: "docker"})}
+
+	result := m.detectDockerUnreachable(available)
+
+	assert.False(t, result)
+}
+
+func TestDetectDockerUnreachable_False_WhenDockerNotInstalled(t *testing.T) {
+	original := utils.CommandExists
+	defer func() { utils.CommandExists = original }()
+	utils.CommandExists = func(_ string) bool { return false }
+
+	m := newTestModelWithRegistry(newTestDockerRegistry())
+
+	result := m.detectDockerUnreachable([]target.Target{})
+
+	assert.False(t, result)
+}
+
+func TestDetectDockerUnreachable_False_WhenDockerNotConfigured(t *testing.T) {
+	original := utils.CommandExists
+	defer func() { utils.CommandExists = original }()
+	utils.CommandExists = func(_ string) bool { return true }
+
+	m := newTestModelWithRegistry(target.NewRegistry())
+
+	result := m.detectDockerUnreachable([]target.Target{})
+
+	assert.False(t, result)
+}

--- a/internal/tui/view_list.go
+++ b/internal/tui/view_list.go
@@ -118,6 +118,10 @@ func (m *Model) listHeader(showSummary bool) string {
 		b.WriteString(m.styles.WarningStyle.Render("[!] Limited access: Grant Full Disk Access in System Settings for complete scan"))
 		b.WriteString("\n")
 	}
+	if m.dockerUnreachable {
+		b.WriteString(m.styles.WarningStyle.Render("[!] Docker not responding: start Docker to include its cleanup"))
+		b.WriteString("\n")
+	}
 	b.WriteString("\n")
 
 	// Legend


### PR DESCRIPTION
## What changed
- `DockerTarget.IsAvailable()` runs `docker version` with a 3s timeout, so a
  stopped/hung daemon returns fast instead of blocking startup.
- List view now hints when Docker is installed but unreachable.

## Why
`IsAvailable()` had no timeout, so a hung Docker daemon froze startup.

## How to test (optional)
- `go test ./internal/target/ ./internal/tui/`

Closes #65
